### PR TITLE
feat(immich): move ingress from external to internal

### DIFF
--- a/kubernetes/apps/default/immich/app/server/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/server/helmrelease.yaml
@@ -136,9 +136,8 @@ spec:
             port: *port
     ingress:
       app:
-        className: external
+        className: internal
         annotations:
-          external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
           nginx.ingress.kubernetes.io/proxy-body-size: "0"
           nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
           nginx.ingress.kubernetes.io/proxy-send-timeout: "300"


### PR DESCRIPTION
## Summary
- Large uploads (phone videos, Live Photos) hit Cloudflare's proxied request body cap on the `external` ingress. Moving to `internal` removes the cap entirely.
- Remote access continues to work over Tailscale (user confirmed).

## Change
- `className: external` → `internal`
- Dropped `external-dns.alpha.kubernetes.io/target` annotation (internal DNS covers the host)
- nginx `proxy-body-size`, `client-max-body-size`, and timeout annotations kept — they still apply on the internal ingress-nginx controller and are what Immich's own upload handler needs.

## Test plan
- [ ] After reconcile, `kubectl -n default get ingress immich-server` shows `CLASS=internal`
- [ ] `photos.ekenhome.se` resolves internally (via Tailscale / LAN DNS) and the web UI loads
- [ ] Upload a large (>200 MB) video from the Immich mobile app over Tailscale → completes without 413
- [ ] External (Cloudflare) DNS record for `photos.ekenhome.se` is removed by external-dns once the annotation is gone (verify in Cloudflare dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)