### PR TITLE
fix(system-upgrade-controller): make Talos plan upgrades survive busy nodes

### DIFF
--- a/kubernetes/apps/kube-tools/system-upgrade-controller/WORKER3-RUNBOOK.md
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/WORKER3-RUNBOOK.md
@@ -1,22 +1,39 @@
-# worker3 — Manual Talos Upgrade Runbook
+# worker3 — Talos Upgrade Runbook (automated, with manual fallback)
 
-**Why this node is special:** `worker3` uses an AMD CPU/GPU. The rest of the
-cluster (master1–3) runs Intel and relies on
-`intel-device-plugins-gpu` for iGPU scheduling. The
+**Why this node is special:** `worker3` uses an AMD CPU/GPU. The rest of
+the cluster (master1–3) runs Intel and relies on
+`intel-device-plugins-gpu` for iGPU scheduling. The control-plane
 `system-upgrade-controller` Plan at
 `kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml`
-explicitly excludes `worker3` via nodeSelector so that a generic
-Intel-focused upgrade can't break AMD-specific drivers or Talos
-extensions.
+explicitly excludes `worker3` via nodeSelector so a generic Intel-focused
+upgrade can't apply the wrong schematic.
 
-As a result, worker3 must be upgraded by hand whenever the rest of the
-cluster moves to a new Talos version.
+worker3 is now upgraded automatically by a dedicated
+[`talos-worker3`](./plans/talos-worker3.yaml) Plan that pins
+`TALOS_SCHEMATIC_WORKER3` (the AMD schematic ID lives in
+[`ks.yaml`](./ks.yaml)). The manual steps below are kept as a fallback
+for when the Plan fails (e.g. Job DeadlineExceeded).
 
 ## When to upgrade
 
-After the automated system-upgrade-controller run finishes upgrading the
-other three nodes (check with `kubectl get nodes -o wide`), schedule a
-separate window for worker3.
+Normally: nothing — the `talos-worker3` Plan picks the new version up
+automatically when Renovate bumps `TALOS_VERSION`. Watch
+`kubectl get nodes -o wide` and the Plan status:
+
+```bash
+kubectl get plan -n kube-tools talos-worker3
+```
+
+Fall back to the manual procedure only if the Plan is wedged. Common
+failure modes:
+
+- Plan condition `Complete=False`, message `DeadlineExceeded` — the
+  upgrade Job ran past `spec.jobActiveDeadlineSecs`. The Plan now sets
+  this to 2700s and `drain.disableEviction: true`; if you still hit it,
+  inspect the failed Job logs before bumping further.
+- Node stuck `SchedulingDisabled` with no Job running — SUC cordoned it
+  but the Job aged out. Uncordon and let SUC retry, or proceed manually
+  below.
 
 ## Prerequisites
 

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/app/helmrelease.yaml
@@ -36,7 +36,12 @@ spec:
             env:
               SYSTEM_UPGRADE_CONTROLLER_DEBUG: false
               SYSTEM_UPGRADE_CONTROLLER_THREADS: 2
-              SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: 900
+              # 45-min ceiling per upgrade Job. Plans can override via
+              # spec.jobActiveDeadlineSecs. The old 900s left no headroom once
+              # `talosctl health` ran with --wait-timeout=10m before the
+              # upgrade phase even started (saw both master1 and worker3
+              # DeadlineExceeded on the v1.13.2→v1.13.3 roll).
+              SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: 2700
               SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: 99
               SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: IfNotPresent
               SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: registry.k8s.io/kubectl:v1.35.5

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
@@ -15,6 +15,7 @@ spec:
       ignoreUpdates: true
   concurrency: 1
   exclusive: true
+  jobActiveDeadlineSecs: 2700
   nodeSelector:
     matchExpressions:
       - key: feature.node.kubernetes.io/system-os_release.ID
@@ -26,6 +27,14 @@ spec:
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
+  # See plans/talos.yaml for rationale on disableEviction.
+  drain:
+    force: true
+    disableEviction: true
+    deleteEmptydirData: true
+    ignoreDaemonSets: true
+    skipWaitForDeleteTimeout: 5
+    timeout: 10m
   prepare: &prepare
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
@@ -40,7 +49,7 @@ spec:
       # runs the check client-side. Required for worker plans (control-plane
       # plans can omit it). See talos.yaml.
       - --server=false
-      - --wait-timeout=10m
+      - --wait-timeout=3m
   upgrade:
     <<: *prepare
     args:

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
@@ -15,6 +15,7 @@ spec:
       ignoreUpdates: true
   concurrency: 1
   exclusive: true
+  jobActiveDeadlineSecs: 2700
   nodeSelector:
     matchExpressions:
       - key: feature.node.kubernetes.io/system-os_release.ID
@@ -29,6 +30,17 @@ spec:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
+  # Drain before Talos's own upgrade reboot so PDB-protected pods (postgres,
+  # knative activator, nginx-external) don't stall the upgrade past the Job
+  # deadline. disableEviction force-deletes pods that PDBs would otherwise
+  # block — acceptable for a planned host reboot.
+  drain:
+    force: true
+    disableEviction: true
+    deleteEmptydirData: true
+    ignoreDaemonSets: true
+    skipWaitForDeleteTimeout: 5
+    timeout: 10m
   prepare: &prepare
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
@@ -39,7 +51,7 @@ spec:
     args:
       - --nodes=$(NODE_IP)
       - health
-      - --wait-timeout=10m
+      - --wait-timeout=3m
   upgrade:
     <<: *prepare
     args:


### PR DESCRIPTION
## Summary
- v1.13.2 → v1.13.3 roll wedged `master1` and `worker3`: both upgrade Jobs hit `DeadlineExceeded` (900s ceiling) and never retried, leaving the nodes cordoned with no Job to clean up. `talosctl health --wait-timeout=10m` in the prepare phase could eat 10 of those 15 minutes before the upgrade phase even started.
- Plans now ship an explicit `drain:` block with `disableEviction: true` so PDB-protected pods (postgres, knative activator, nginx-external) don't stall the upgrade. Health `--wait-timeout` tightened from 10m → 3m so prepare can't starve the upgrade phase.
- `jobActiveDeadlineSecs: 2700` per Plan, with matching 2700s ceiling on the controller env var.
- `WORKER3-RUNBOOK.md` updated — worker3 is automated via `talos-worker3` Plan now; manual procedure kept as fallback.

## Test plan
- [x] Live cluster: SUC scaled to 0 + Flux suspended for `system-upgrade-controller{,-plans}` while this PR lands
- [x] master1 + worker3 manually uncordoned; ~30 Pending pods recovered
- [ ] After merge: Flux applies, scale SUC back up, watch master1 → master2 → master3 roll to Talos v1.13.3 (control-plane plan, concurrency=1)
- [ ] worker3 rolls to v1.13.3 via `talos-worker3` plan
- [ ] All 4 nodes land Ready at v1.13.3

## Follow-ups
- Single-replica PDBs with `minAvailable: 1` (postgres-set-postgres, knative activator-pdb, nginx-external-controller) are bypassed by `disableEviction` during upgrades but still block manual drains. Track separately ([[project_mosquitto_pdb_min_available]] foot-gun pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)