### PR TITLE
fix(system-upgrade-controller): drop broken prepare step from Talos plans

### DIFF
--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
@@ -35,23 +35,14 @@ spec:
     ignoreDaemonSets: true
     skipWaitForDeleteTimeout: 5
     timeout: 10m
-  prepare: &prepare
+  # No prepare — see plans/talos.yaml for rationale.
+  upgrade:
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
       - name: NODE_IP
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
-    args:
-      - --nodes=$(NODE_IP)
-      - health
-      # Worker nodes cannot serve the cluster health-check RPC; --server=false
-      # runs the check client-side. Required for worker plans (control-plane
-      # plans can omit it). See talos.yaml.
-      - --server=false
-      - --wait-timeout=3m
-  upgrade:
-    <<: *prepare
     args:
       - --nodes=$(NODE_IP)
       - upgrade

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
@@ -41,19 +41,18 @@ spec:
     ignoreDaemonSets: true
     skipWaitForDeleteTimeout: 5
     timeout: 10m
-  prepare: &prepare
+  # No prepare: SUC cordons the target node before running prepare, and
+  # `talosctl health` in 1.13.3 fails the cluster check on any unschedulable
+  # node — i.e. the target — so prepare can never pass. Talos's upgrade
+  # itself refuses to run on an unhealthy cluster (etcd quorum, control
+  # plane), so this safety net survives without the duplicate pre-flight.
+  upgrade:
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
       - name: NODE_IP
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
-    args:
-      - --nodes=$(NODE_IP)
-      - health
-      - --wait-timeout=3m
-  upgrade:
-    <<: *prepare
     args:
       - --nodes=$(NODE_IP)
       - upgrade


### PR DESCRIPTION
## Summary
- Follow-up to #5565. After merging that PR the v1.13.2 → v1.13.3 roll *still* deadlocked: `talosctl health` in 1.13.3 added a "all k8s nodes report schedulable" check, and SUC cordons the target node before running prepare — so the check fails permanently on the target itself with `context deadline exceeded`.
- Symptom: every retry of `apply-talos-on-master1-...` / `apply-talos-worker3-on-worker3-...` exited with `Init:Error` in ~3 min (the new tightened wait-timeout), upgrade phase never reached.
- Remove `prepare:` from both Plans. Talos's own upgrade refuses to run on an unhealthy cluster (etcd quorum, control-plane readiness checks built into `talosctl upgrade`), and the SUC drain block (force + disableEviction) already handles eviction-blocking PDBs.

## Test plan
- [x] SUC scaled to 0, both nodes uncordoned, cluster idle on v1.13.2
- [ ] After merge: Flux applies, scale SUC back up, watch master1 → master2 → master3 land at v1.13.3 (talos plan, concurrency=1)
- [ ] worker3 rolls to v1.13.3 via talos-worker3 plan
- [ ] All 4 nodes Ready at v1.13.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)