### PR TITLE
fix(system-upgrade-controller): pass --wait=false to talosctl upgrade

### DIFF
--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
@@ -35,7 +35,7 @@ spec:
     ignoreDaemonSets: true
     skipWaitForDeleteTimeout: 5
     timeout: 10m
-  # No prepare — see plans/talos.yaml for rationale.
+  # No prepare; --wait=false on upgrade — see plans/talos.yaml for rationale.
   upgrade:
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
@@ -49,3 +49,4 @@ spec:
       - --image=factory.talos.dev/metal-installer/${TALOS_SCHEMATIC_WORKER3}:${TALOS_VERSION}
       - --preserve
       - --reboot-mode=powercycle
+      - --wait=false

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
@@ -41,11 +41,11 @@ spec:
     ignoreDaemonSets: true
     skipWaitForDeleteTimeout: 5
     timeout: 10m
-  # No prepare: SUC cordons the target node before running prepare, and
-  # `talosctl health` in 1.13.3 fails the cluster check on any unschedulable
-  # node — i.e. the target — so prepare can never pass. Talos's upgrade
-  # itself refuses to run on an unhealthy cluster (etcd quorum, control
-  # plane), so this safety net survives without the duplicate pre-flight.
+  # No prepare: see git history. talosctl 1.13.3's health check insists on
+  # all nodes schedulable, but SUC cordons the target before running prepare
+  # — so it can never pass. Talos's upgrade itself refuses to run on an
+  # unhealthy cluster (etcd quorum, control plane), so this safety net
+  # survives without the duplicate pre-flight.
   upgrade:
     image: ghcr.io/siderolabs/talosctl:${TALOS_VERSION}
     envs:
@@ -59,3 +59,8 @@ spec:
       - --image=factory.talos.dev/metal-installer/${TALOS_SCHEMATIC}:${TALOS_VERSION}
       - --preserve
       - --reboot-mode=powercycle
+      # --wait=false: skip talosctl's built-in cordon/drain/wait/uncordon.
+      # SUC already cordons + drains via the init container; the upgrade
+      # pod runs ON the target node and would otherwise be evicted by
+      # talosctl's own drain → Job marks Failed → infinite retry loop.
+      - --wait=false


### PR DESCRIPTION
## Summary
- Follow-up to #5566. Even with prepare removed, SUC's upgrade pods died within ~1 second of starting. Root cause: `talosctl upgrade` defaults to `--wait=true`, which runs its own cordon → drain → reboot → wait → uncordon sequence. SUC's upgrade Job pod runs ON the target node, so talosctl's built-in drain evicts the upgrade pod itself before the upgrade RPC is even sent.
- Confirmed by running the identical command (minus `--wait=false`, plus `--debug`) from a debug pod scheduled OFF the target node — it completed in ~3 min and worker3 upgraded successfully to Talos v1.13.3.
- Worker3 is already on v1.13.3 from that one-off debug run. master1/2/3 are still on v1.13.2; SUC will roll them after this lands.

## Test plan
- [x] Debug pod (off target node) → talosctl upgrade succeeded → worker3 on v1.13.3
- [ ] After merge: resume Flux + SUC, watch master1 → master2 → master3 land at v1.13.3 (control-plane plan, concurrency=1, single per-Plan target since worker3 is already done)
- [ ] talos-worker3 plan reconciles to Complete (worker3 already at target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)