### PR TITLE
fix(system-upgrade-controller): add --drain=false to talosctl upgrade

### DIFF
--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos-worker3.yaml
@@ -49,4 +49,5 @@ spec:
       - --image=factory.talos.dev/metal-installer/${TALOS_SCHEMATIC_WORKER3}:${TALOS_VERSION}
       - --preserve
       - --reboot-mode=powercycle
+      - --drain=false
       - --wait=false

--- a/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/kube-tools/system-upgrade-controller/plans/talos.yaml
@@ -59,8 +59,12 @@ spec:
       - --image=factory.talos.dev/metal-installer/${TALOS_SCHEMATIC}:${TALOS_VERSION}
       - --preserve
       - --reboot-mode=powercycle
-      # --wait=false: skip talosctl's built-in cordon/drain/wait/uncordon.
-      # SUC already cordons + drains via the init container; the upgrade
-      # pod runs ON the target node and would otherwise be evicted by
-      # talosctl's own drain → Job marks Failed → infinite retry loop.
+      # talosctl upgrade has two independent defaults that must both be
+      # disabled. --drain=true (default) cordons the target and evicts
+      # pods — and since the SUC upgrade pod runs ON the target node,
+      # talosctl's own drain evicts it before the upgrade RPC fires.
+      # --wait=true (default) then blocks waiting for the node to come
+      # back. SUC already cordons + drains via the init container, so
+      # the upgrade pod just needs to send the RPC and exit.
+      - --drain=false
       - --wait=false


### PR DESCRIPTION
## Summary
- Follow-up to #5567. `--wait=false` alone wasn't enough: talosctl 1.13.3's `upgrade` has TWO independently-defaulted flags — `--wait=true` AND `--drain=true`. With drain still on, talosctl was still cordoning + evicting pods on the target node, which includes the upgrade pod itself. Same death loop as before.
- This PR sets both `--drain=false` and `--wait=false`. SUC's controller already cordons; SUC's init container already drains via `kubectl drain` (with the `--pod-selector !upgrade.cattle.io/controller` exclusion that talosctl lacks). The upgrade pod just needs to send the RPC and exit.

## Test plan
- [x] talosctl 1.13.3 `upgrade --help` confirmed: `--drain bool (default true)` exists as a separate flag from `--wait`
- [ ] After merge: resume Flux + SUC, watch master1 → master2 → master3 land at v1.13.3
- [ ] talos-worker3 plan reconciles to Complete (worker3 already on v1.13.3 — re-roll will trigger Talos's no-op-same-image path, or it'll reboot once more harmlessly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)