### PR TITLE
feat(home-assistant): move recorder DB to crunchy-postgres

### DIFF
--- a/kubernetes/apps/database/crunchy-postgres/cluster/cluster.yaml
+++ b/kubernetes/apps/database/crunchy-postgres/cluster/cluster.yaml
@@ -198,6 +198,10 @@ spec:
       databases: ["rybbit"]
       password:
         type: AlphaNumeric
+    - name: "home-assistant"
+      databases: ["home-assistant"]
+      password:
+        type: AlphaNumeric
   backups:
     pgbackrest:
       configuration: &backupConfig

--- a/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name home-assistant-db-secret
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: crunchy-pgo-secrets
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      data:
+        # Full recorder connection string. HOST points to the primary (.host),
+        # not pgbouncer: the pgbouncer proxy runs in transaction pool mode which
+        # breaks SQLAlchemy server-side cursors / SET LOCAL used by the recorder.
+        # configuration.yaml consumes this via: db_url: !env_var HASS_RECORDER_DB_URL
+        HASS_RECORDER_DB_URL: 'postgresql://{{ .user }}:{{ .password }}@{{ .host }}:{{ .port }}/{{ .dbname }}'
+  dataFrom:
+    - extract:
+        key: postgres-pguser-home-assistant

--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -39,6 +39,13 @@ spec:
               tag: 2026.5.4@sha256:affa384bad3868c07ea507760baec149aae4074a756fd3352dd9f52cc171d65a
             env:
               TZ: ${TIMEZONE}
+              # Recorder connection string (crunchy-postgres primary).
+              # Consumed by configuration.yaml: db_url: !env_var HASS_RECORDER_DB_URL
+              HASS_RECORDER_DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: home-assistant-db-secret
+                    key: HASS_RECORDER_DB_URL
             securityContext:
               runAsUser: 0
               runAsGroup: 0

--- a/kubernetes/apps/default/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/default/home-assistant/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./rbac.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ../../../../templates/gatus/external
   - ../../../../templates/volsync


### PR DESCRIPTION
## Problem

The HA restic repo in MinIO bloats repeatedly (154 GiB on 2026-05-21, regrew by 2026-05-29 on a 9.5–15 Gi source PVC). Root cause: the default recorder writes a multi-GB SQLite file (`home-assistant_v2.db`) on the config PVC that churns constantly. volsync snapshots that PVC **hourly** and retains ~39 snapshots; restic can't dedupe a churning SQLite file, so every snapshot stores ~1.2 GiB and the repo balloons. Prune only runs every 10 days, so discarded snapshots' packs linger as dead data between prunes.

## Fix

Move the recorder database off the backed-up PVC into the existing crunchy-postgres cluster (own efficient pgBackRest backups). The config volume then goes static and volsync snapshots stay tiny.

- `cluster.yaml` — add `home-assistant` user + database
- `externalsecret.yaml` (new) — build `HASS_RECORDER_DB_URL` from `postgres-pguser-home-assistant`, pointed at the **primary** (`.host`, not pgbouncer: transaction pool mode breaks the recorder's SQLAlchemy server-side cursors). Password stays out of git and off disk.
- `helmrelease.yaml` — inject `HASS_RECORDER_DB_URL` (Reloader already on)
- `kustomization.yaml` — register the new secret

`kubectl kustomize` passes for both the HA app and the cluster.

## Required manual step (post-merge)

`configuration.yaml` lives on the PVC, not git. After Flux applies this, add via code-server and restart HA:

```yaml
recorder:
  db_url: !env_var HASS_RECORDER_DB_URL
  purge_keep_days: 10
```

Until then HA keeps using SQLite and nothing changes. Switching to Postgres starts HA history fresh. Afterward, delete stale `/config/home-assistant_v2.db*` to free the PVC; the next volsync prune reclaims the old dead packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)