### PR TITLE
fix(ha-mcp): mount writable emptyDir at /tmp

### DIFF
--- a/kubernetes/apps/datasci/toolhive/ha-mcp/mcpserver.yaml
+++ b/kubernetes/apps/datasci/toolhive/ha-mcp/mcpserver.yaml
@@ -19,3 +19,13 @@ spec:
         - name: mcp
           command:
             - ha-mcp-web
+          # toolhive enforces readOnlyRootFilesystem, so Python's
+          # tempfile.gettempdir() finds no writable dir and the server
+          # crashes on startup with "No usable temporary directory found".
+          # A writable emptyDir at /tmp lets it fall back to /tmp/ha-mcp.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Problem
`ha-mcp` has been in CrashLoopBackOff for ~49 days. Toolhive enforces `readOnlyRootFilesystem` on the MCP container, so Python's `tempfile.gettempdir()` finds no writable directory and the server crashes on startup:

```
FileNotFoundError: [Errno 2] No usable temporary directory found in
['/tmp', '/var/tmp', '/usr/tmp', '/app']
```

## Fix
Mount a writable `emptyDir` at `/tmp` via `podTemplateSpec` (same mechanism the working `memory-mcp` sibling uses for its data volume). ha-mcp then falls back to `/tmp/ha-mcp` for `tool_config.json`.

**Verified live:** after applying, `ha-mcp-0` reaches `1/1 Running` and the MCPServer reports `Ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)