### PR TITLE
feat(development): add alphaos app

### DIFF
--- a/kubernetes/apps/database/crunchy-postgres/cluster/cluster.yaml
+++ b/kubernetes/apps/database/crunchy-postgres/cluster/cluster.yaml
@@ -178,6 +178,10 @@ spec:
       databases: ["hempriser"]
       password:
         type: AlphaNumeric
+    - name: "alphaos"
+      databases: ["alphaos"]
+      password:
+        type: AlphaNumeric
     - name: "bandit"
       databases: ["bandit"]
       password:

--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -1,0 +1,94 @@
+---
+# AlphaOS — multi-asset levels/momentum research engine + paper-trade ledger (FastAPI dashboard).
+# Public image, no imagePullSecret needed. Exposed via internal Ingress at alphaos.${SECRET_DOMAIN}.
+# Loads historical data from MinIO (bucket stocks-us) when alphaos-minio creds exist, else yfinance.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alphaos
+  namespace: development
+  labels:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: app
+spec:
+  # ReadWriteOnce PVC ⇒ single replica.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alphaos
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alphaos
+        app.kubernetes.io/component: app
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: app
+          image: ghcr.io/ekenheim/alphaos:sha-0fcf829
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8503
+              protocol: TCP
+          env:
+            # Force the MinIO loader; harmless if creds are absent (falls back to yfinance).
+            - name: ALPHAOS_USE_MINIO
+              value: "1"
+            - name: MINIO_BUCKET
+              value: "stocks-us"
+          envFrom:
+            # MinIO creds; optional so the app deploys (yfinance fallback) before the secret exists.
+            - secretRef:
+                name: alphaos-minio
+                optional: true
+            # Postgres (DATABASE_URL / PG_CONNECTION_STRING); optional until the DB user is provisioned.
+            - secretRef:
+                name: alphaos-postgres
+                optional: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: data-cache
+              mountPath: /app/alphaos/data_cache
+          # Initial dashboard computation takes 10–30s; startupProbe guards the cold start.
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 6
+      volumes:
+        - name: data-cache
+          persistentVolumeClaim:
+            claimName: alphaos-data-cache

--- a/kubernetes/apps/development/alphaos/app/externalsecret.yaml
+++ b/kubernetes/apps/development/alphaos/app/externalsecret.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# MinIO/S3 credentials for the AlphaOS market-data loader (parquet from bucket "stocks-us").
+# Reuses the SAME Bitwarden item as hempriser ("hempriser-minio"), remapping its fields
+# (MINIO_ENDPOINT / MINIO_ACCESS_KEY / MINIO_SECRET_KEY) onto the env var names AlphaOS reads.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-minio
+  namespace: development
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  target:
+    name: alphaos-minio
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        MINIO_ENDPOINT_URL: "http://{{ .MINIO_ENDPOINT }}"
+        MINIO_ACCESS_KEY_ID: "{{ .MINIO_ACCESS_KEY }}"
+        MINIO_SECRET_ACCESS_KEY: "{{ .MINIO_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: hempriser-minio
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# Postgres connection string for AlphaOS (database "alphaos"). Routes via PgBouncer.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-postgres
+  namespace: development
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: crunchy-pgo-secrets
+    kind: ClusterSecretStore
+  target:
+    name: alphaos-postgres
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      data:
+        PG_CONNECTION_STRING: 'postgresql://{{ .user }}:{{ .password }}@{{ index . "pgbouncer-host" }}:5432/{{ .dbname }}'
+        DATABASE_URL: 'postgresql://{{ .user }}:{{ .password }}@{{ index . "pgbouncer-host" }}:5432/{{ .dbname }}'
+  dataFrom:
+    - extract:
+        key: postgres-pguser-alphaos

--- a/kubernetes/apps/development/alphaos/app/ingress.yaml
+++ b/kubernetes/apps/development/alphaos/app/ingress.yaml
@@ -1,0 +1,31 @@
+---
+# AlphaOS dashboard at alphaos.${SECRET_DOMAIN} (internal ingress). TLS and DNS via cert-manager / external-dns.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alphaos
+  namespace: development
+  labels:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: app
+  annotations:
+    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: AlphaOS
+    gethomepage.dev/group: Development
+spec:
+  ingressClassName: internal
+  rules:
+    - host: alphaos.${SECRET_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: alphaos
+                port:
+                  number: 8503
+  tls:
+    - hosts:
+        - alphaos.${SECRET_DOMAIN}

--- a/kubernetes/apps/development/alphaos/app/kustomization.yaml
+++ b/kubernetes/apps/development/alphaos/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./ingress.yaml

--- a/kubernetes/apps/development/alphaos/app/pvc.yaml
+++ b/kubernetes/apps/development/alphaos/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+# Standalone PVC for the AlphaOS parquet cache + append-only JSON trade ledger
+# (mounted at /app/alphaos/data_cache). VolSync disabled; this is regenerable cache/ledger data.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "${CLAIM:-alphaos-data-cache}"
+  labels:
+    app.kubernetes.io/name: "${APP:-alphaos}"
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: "${VOLSYNC_CAPACITY:-2Gi}"
+  storageClassName: "ceph-block"

--- a/kubernetes/apps/development/alphaos/app/service.yaml
+++ b/kubernetes/apps/development/alphaos/app/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alphaos
+  namespace: development
+  labels:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: app
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8503
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: app

--- a/kubernetes/apps/development/alphaos/ks.yaml
+++ b/kubernetes/apps/development/alphaos/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alphaos
+  namespace: flux-system
+spec:
+  targetNamespace: development
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: alphaos
+  path: ./kubernetes/apps/development/alphaos/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: external-secrets
+    - name: crunchy-postgres-operator-cluster
+    - name: crunchy-postgres-stores
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets

--- a/kubernetes/apps/development/kustomization.yaml
+++ b/kubernetes/apps/development/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./alphaos/ks.yaml
   #- ./umami/ks.yaml
   - ./bytewax/ks.yaml
   #- ./meilisearch/ks.yaml


### PR DESCRIPTION
Deploys [ekenheim/alphaos](https://github.com/ekenheim/alphaos) (FastAPI research engine + paper-trade ledger) in the `development` namespace, following the standard app layout.

## What
- **Deployment** — `ghcr.io/ekenheim/alphaos:sha-0fcf829` (public image, no pull secret), port 8503, runs as uid 10001, `Recreate` strategy (RWO PVC), startup/liveness/readiness on `/api/health`.
- **Service** ClusterIP :8503 + **internal Ingress** at `alphaos.${SECRET_DOMAIN}` (`ingressClassName: internal`).
- **PVC** 2Gi `ceph-block` mounted at `/app/alphaos/data_cache` (parquet cache + JSON ledger).
- **MinIO** — `alphaos-minio` ExternalSecret reuses the **same Bitwarden item as hempriser** (`hempriser-minio`), remapping fields to the env names AlphaOS reads (`MINIO_ENDPOINT_URL`/`MINIO_ACCESS_KEY_ID`/`MINIO_SECRET_ACCESS_KEY`).
- **Postgres** — dedicated `alphaos` user/db added to crunchy-postgres; `alphaos-postgres` ExternalSecret provides `DATABASE_URL`/`PG_CONNECTION_STRING` (wired `optional`).
- Enabled in the development namespace kustomization; `ks.yaml` dependsOn external-secrets + crunchy-postgres.

## Notes
- Both MinIO and Postgres envFrom are `optional: true`, so the pod starts even before secrets/DB exist (MinIO falls back to yfinance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)