### PR TITLE
feat(development): roll alphaos forward to sha-adb2bbc + DB migrations

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -31,9 +31,45 @@ spec:
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
+      initContainers:
+        # Create/upgrade the Postgres ledger + backtest-archive schema before the app starts.
+        # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
+        - name: db-migrate
+          image: ghcr.io/ekenheim/alphaos:sha-adb2bbc
+          command: ["alphaos", "db", "upgrade"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alphaos-postgres
+                  key: DATABASE_URL
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+        # Idempotent seed of the strategy catalog.
+        - name: db-seed
+          image: ghcr.io/ekenheim/alphaos:sha-adb2bbc
+          command: ["alphaos", "db", "seed"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alphaos-postgres
+                  key: DATABASE_URL
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:sha-0fcf829
+          image: ghcr.io/ekenheim/alphaos:sha-adb2bbc
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
@@ -54,7 +90,8 @@ spec:
             - secretRef:
                 name: alphaos-minio
                 optional: true
-            # Postgres (DATABASE_URL / PG_CONNECTION_STRING); optional until the DB user is provisioned.
+            # Postgres (DATABASE_URL direct + DATABASE_URL_POOLED); optional so the app still
+            # starts if the secret is missing.
             - secretRef:
                 name: alphaos-postgres
                 optional: true

--- a/kubernetes/apps/development/alphaos/app/externalsecret.yaml
+++ b/kubernetes/apps/development/alphaos/app/externalsecret.yaml
@@ -28,7 +28,10 @@ spec:
         key: hempriser-minio
 ---
 # yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-# Postgres connection string for AlphaOS (database "alphaos"). Routes via PgBouncer.
+# Postgres connection for AlphaOS (database "alphaos"). DATABASE_URL uses the DIRECT primary
+# uri (not PgBouncer): AlphaOS runs schema migrations (`alphaos db upgrade`), and PgBouncer
+# transaction pooling breaks SCRAM-SHA-256 schema management (see hempriser-dagster-db).
+# DATABASE_URL_POOLED exposes the pooler for read/write traffic if ever needed.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -46,8 +49,8 @@ spec:
     template:
       type: Opaque
       data:
-        PG_CONNECTION_STRING: 'postgresql://{{ .user }}:{{ .password }}@{{ index . "pgbouncer-host" }}:5432/{{ .dbname }}'
-        DATABASE_URL: 'postgresql://{{ .user }}:{{ .password }}@{{ index . "pgbouncer-host" }}:5432/{{ .dbname }}'
+        DATABASE_URL: "{{ .uri }}"
+        DATABASE_URL_POOLED: "{{ index . \"pgbouncer-uri\" }}"
   dataFrom:
     - extract:
         key: postgres-pguser-alphaos


### PR DESCRIPTION
Per the AlphaOS team: the live image `sha-0fcf829` predates the Postgres ledger feature. This rolls forward to `sha-adb2bbc` and runs the schema migrations the new image needs.

## Changes
- **Image** → `ghcr.io/ekenheim/alphaos:sha-adb2bbc` (verified public, HTTP 200).
- **initContainers** `db-migrate` (`alphaos db upgrade`) + `db-seed` (`alphaos db seed`) run before the app.
- **DATABASE_URL = direct primary `uri`**, not PgBouncer — schema/DDL management breaks under PgBouncer transaction pooling (SCRAM-SHA-256), the same gotcha documented for hempriser/dagster. `DATABASE_URL_POOLED` (pgbouncer-uri) exposed for pooled traffic if needed.
- Init containers reference the **in-namespace `alphaos-postgres` secret** — the team's snippet pointed at `postgres-pguser-alphaos`, which only exists in the `database` namespace.

## Already in place
- `ALPHAOS_USE_MINIO=1` + `MINIO_BUCKET=stocks-us` on the app container (MinIO loader enabled; yfinance fallback otherwise).
- PVC mounted at `/app/alphaos/data_cache`; `readOnlyRootFilesystem: false` (no separate writable `/tmp` needed).

## Open item
- Worth confirming hempriser's MinIO actually has the `stocks-us` bucket laid out as `bars/tf={1min,5min,15min,1day}/date=YYYY-MM-DD/part.parquet`, else the loader finds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)