### PR TITLE
fix(development): point alphaos at LAN MinIO (s3-lan) for stocks-us

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -85,6 +85,10 @@ spec:
               value: "1"
             - name: MINIO_BUCKET
               value: "stocks-us"
+            # LAN MinIO that holds stocks-us (parquet bars). Plain http on :9000 (no TLS).
+            # NOT the in-cluster minio-secondary, which has no stocks-us bucket.
+            - name: MINIO_ENDPOINT_URL
+              value: "http://s3-lan.ekenhome.se:9000"
           envFrom:
             # MinIO creds; optional so the app deploys (yfinance fallback) before the secret exists.
             - secretRef:

--- a/kubernetes/apps/development/alphaos/app/externalsecret.yaml
+++ b/kubernetes/apps/development/alphaos/app/externalsecret.yaml
@@ -1,8 +1,9 @@
 ---
 # yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 # MinIO/S3 credentials for the AlphaOS market-data loader (parquet from bucket "stocks-us").
-# Reuses the SAME Bitwarden item as hempriser ("hempriser-minio"), remapping its fields
-# (MINIO_ENDPOINT / MINIO_ACCESS_KEY / MINIO_SECRET_KEY) onto the env var names AlphaOS reads.
+# Reuses the SAME Bitwarden item as hempriser ("hempriser-minio") for the access/secret keys.
+# These creds authenticate against the LAN MinIO (s3-lan.ekenhome.se:9000) where stocks-us lives;
+# the endpoint itself is a plain (non-secret) env set on the Deployment, not here.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -20,7 +21,6 @@ spec:
       engineVersion: v2
       type: Opaque
       data:
-        MINIO_ENDPOINT_URL: "http://{{ .MINIO_ENDPOINT }}"
         MINIO_ACCESS_KEY_ID: "{{ .MINIO_ACCESS_KEY }}"
         MINIO_SECRET_ACCESS_KEY: "{{ .MINIO_SECRET_KEY }}"
   dataFrom:


### PR DESCRIPTION
The in-cluster `minio-secondary` (hempriser's endpoint) has **no `stocks-us` bucket**, so alphaos was silently falling back to yfinance. The market-data parquet lives on the **LAN MinIO** at `http://s3-lan.ekenhome.se:9000`.

## Verified from the running pod
- `stocks-us` **exists** on `s3-lan` with the expected layout: `bars/tf={1min,5min,15min,1day}/date=YYYY-MM-DD/part.parquet` (e.g. `bars/tf=15min/date=2016-06-01/part.parquet`).
- The shared **hempriser-minio creds authenticate** against s3-lan.
- `:9000` is plain **http** (https → `WRONG_VERSION_NUMBER`).

## Change
- `MINIO_ENDPOINT_URL=http://s3-lan.ekenhome.se:9000` as a plain env on the Deployment (non-secret hostname).
- `alphaos-minio` ExternalSecret now carries only `MINIO_ACCESS_KEY_ID` / `MINIO_SECRET_ACCESS_KEY` (still from the shared `hempriser-minio` Bitwarden item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)