### PR TITLE
feat(development): roll alphaos to sha-7df2288 (migration 0003 + re-add MinIO)

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -1,6 +1,7 @@
 ---
-# AlphaOS — V2-FRONTIER portfolio tracker (FastAPI dashboard). All state in Postgres;
-# no market-data/MinIO and no local files. Public image, no imagePullSecret needed.
+# AlphaOS — V2-FRONTIER portfolio tracker (FastAPI dashboard). State in Postgres; no local files.
+# Reads the read-only stocks-us MinIO bucket (s3-lan) for US-stock pricing; FX is fetched live
+# from Riksbank/ECB (outbound internet). Public image, no imagePullSecret needed.
 # Exposed via internal Ingress at alphaos.${SECRET_DOMAIN}.
 apiVersion: apps/v1
 kind: Deployment
@@ -32,11 +33,11 @@ spec:
         runAsGroup: 10001
         fsGroup: 10001
       initContainers:
-        # Migrate the Postgres schema before the app starts. Migration 0002 drops the old
-        # ledger tables and creates the V2-FRONTIER schema.
+        # Migrate the Postgres schema before the app starts (alembic; currently up to 0003 —
+        # holdings cost-basis + config FX columns).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:sha-92c48cd
+          image: ghcr.io/ekenheim/alphaos:sha-7df2288
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -53,7 +54,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:sha-92c48cd
+          image: ghcr.io/ekenheim/alphaos:sha-7df2288
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -70,7 +71,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:sha-92c48cd
+          image: ghcr.io/ekenheim/alphaos:sha-7df2288
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
@@ -80,7 +81,21 @@ spec:
             - name: http
               containerPort: 8503
               protocol: TCP
+          env:
+            # Read the read-only stocks-us bucket for US-stock pricing.
+            - name: ALPHAOS_USE_MINIO
+              value: "1"
+            - name: MINIO_BUCKET
+              value: "stocks-us"
+            # LAN MinIO that holds stocks-us. Plain http on :9000 (no TLS).
+            # NOT the in-cluster minio-secondary, which has no stocks-us bucket.
+            - name: MINIO_ENDPOINT_URL
+              value: "http://s3-lan.ekenhome.se:9000"
           envFrom:
+            # MinIO creds (read-only); optional so the app starts even if the secret lags.
+            - secretRef:
+                name: alphaos-minio
+                optional: true
             # Postgres (DATABASE_URL direct + DATABASE_URL_POOLED).
             - secretRef:
                 name: alphaos-postgres

--- a/kubernetes/apps/development/alphaos/app/externalsecret.yaml
+++ b/kubernetes/apps/development/alphaos/app/externalsecret.yaml
@@ -1,5 +1,33 @@
 ---
 # yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# MinIO/S3 credentials for AlphaOS US-stock pricing (read-only "stocks-us" bucket).
+# Reuses the SAME Bitwarden item as hempriser ("hempriser-minio") for the access/secret keys;
+# they authenticate against the LAN MinIO (s3-lan.ekenhome.se:9000) where stocks-us lives.
+# The endpoint is a plain (non-secret) env set on the Deployment, not here.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-minio
+  namespace: development
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  target:
+    name: alphaos-minio
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        MINIO_ACCESS_KEY_ID: "{{ .MINIO_ACCESS_KEY }}"
+        MINIO_SECRET_ACCESS_KEY: "{{ .MINIO_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: hempriser-minio
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 # Postgres connection for AlphaOS (database "alphaos"). DATABASE_URL uses the DIRECT primary
 # uri (not PgBouncer): AlphaOS runs schema migrations (`alphaos db upgrade`), and PgBouncer
 # transaction pooling breaks SCRAM-SHA-256 schema management (see hempriser-dagster-db).


### PR DESCRIPTION
Roll-forward to `ghcr.io/ekenheim/alphaos:sha-7df2288` (verified public, HTTP 200).

## Changes
- **Image** → `sha-7df2288` (app + both init containers).
- **Migration 0003** runs via the existing `db-migrate` initContainer (`alphaos db upgrade`) — holdings cost-basis + config FX columns.
- **MinIO re-added** (reverses the V2 drop): `stocks-us` is now read **read-only** for US-stock pricing. Restores the `alphaos-minio` ExternalSecret (shared `hempriser-minio` creds) and `ALPHAOS_USE_MINIO=1` / `MINIO_BUCKET=stocks-us` / `MINIO_ENDPOINT_URL=http://s3-lan.ekenhome.se:9000`.
- **`data_cache` PVC stays removed** — app writes no local files.

## FX / egress
FX is fetched live from `api.riksbank.se` / `ecb.europa.eu`. There's no NetworkPolicy in the `development` namespace, so pod egress is unrestricted — FX should work; otherwise rates are set manually in Settings.

## Net resources
Service, Deployment, `alphaos-minio` + `alphaos-postgres` ExternalSecrets, Ingress. Internal-only at `alphaos.${SECRET_DOMAIN}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)