### PR TITLE
feat(development): roll alphaos to sha-e622acb (migration 0005, tx ledger)

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -33,11 +33,11 @@ spec:
         runAsGroup: 10001
         fsGroup: 10001
       initContainers:
-        # Migrate the Postgres schema before the app starts (alembic; currently up to 0003 —
-        # holdings cost-basis + config FX columns).
+        # Migrate the Postgres schema before the app starts (alembic; currently up to 0005 —
+        # transactions ledger; positions are derived from it).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:sha-7df2288
+          image: ghcr.io/ekenheim/alphaos:sha-e622acb
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -54,7 +54,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:sha-7df2288
+          image: ghcr.io/ekenheim/alphaos:sha-e622acb
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -71,7 +71,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:sha-7df2288
+          image: ghcr.io/ekenheim/alphaos:sha-e622acb
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false


### PR DESCRIPTION
Roll-forward to `ghcr.io/ekenheim/alphaos:sha-e622acb` (verified public, HTTP 200).

## Changes
- **Image** → `sha-e622acb` (app + both init containers).
- **Migration 0005** (chain 0001→0005) via the existing `db-migrate` initContainer (`alphaos db upgrade`) — adds the **transactions** table; positions are now derived from the ledger.
- No other infra changes — MinIO (read-only `stocks-us`) + Postgres unchanged, no PVC.

## Post-deploy (UI, your action)
Re-import the Avanza CSV once so it builds the ledger and derives all holdings (idempotent — replaces the date range, never doubles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)