### PR TITLE
feat(development): roll alphaos to sha-de31e09 (v0.4.1)

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         # transactions ledger; positions are derived from it).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:sha-d967c94
+          image: ghcr.io/ekenheim/alphaos:sha-de31e09
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -54,7 +54,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:sha-d967c94
+          image: ghcr.io/ekenheim/alphaos:sha-de31e09
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -71,7 +71,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:sha-d967c94
+          image: ghcr.io/ekenheim/alphaos:sha-de31e09
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false


### PR DESCRIPTION
Roll alphaos forward to `sha-de31e09` (release `0.4.1`), the latest pushed image.

- Built 2026-06-07T16:44Z
- `latest` ghcr tag resolves to this digest; also tagged `0.4.1`
- Bumps all three refs: both initContainers (`db upgrade` / `db seed`) + main container

🤖 Generated with [Claude Code](https://claude.com/claude-code)