### PR TITLE
feat(gatus): move immich and gatus to guarded monitoring template

### DIFF
--- a/kubernetes/apps/default/immich/app/kustomization.yaml
+++ b/kubernetes/apps/default/immich/app/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - ./podmonitor.yaml
   - ./machine-learning
   - ./server
-  - ../../../../templates/gatus/external
+  - ../../../../templates/gatus/guarded

--- a/kubernetes/apps/observability/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/observability/gatus/app/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ./grafana-dashboard.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml
-  - ../../../../templates/gatus/infra
+  - ../../../../templates/gatus/guarded
 configMapGenerator:
   - name: gatus-configmap
     files:


### PR DESCRIPTION
## What

Switch two apps to the `guarded` Gatus monitoring template:

| App | Before | After |
|-----|--------|-------|
| `apps/default/immich` | `templates/gatus/external` (HTTP-200 check) | `templates/gatus/guarded` |
| `apps/observability/gatus` | `templates/gatus/infra` (DNS check, `group: infra`) | `templates/gatus/guarded` |

## Why

Both should report under the `guarded` group with a DNS-resolution check (`[DNS_RCODE] == NOERROR`) against `${GATUS_SUBDOMAIN:-${APP}}.${SECRET_DOMAIN}` rather than an external HTTP / infra check.

## Notes

- No new substitution vars required — `guarded` uses the same `APP` / `SECRET_DOMAIN` / `GATUS_SUBDOMAIN` vars both apps already provided to their prior templates.
- Applies on the next Flux reconcile after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)