### PR TITLE
feat(alphaos): add dagster market-data pipeline (v0.5.1)

### DIFF
--- a/kubernetes/apps/datasci/dagster/app/externalsecret.yaml
+++ b/kubernetes/apps/datasci/dagster/app/externalsecret.yaml
@@ -223,3 +223,60 @@ spec:
   dataFrom:
     - extract:
         key: postgres-pguser-gridreliance
+---
+# MinIO creds for alphaos run pods (market-data pipeline writes to the "stocks-us" bucket on
+# the LAN MinIO). Reuses the SAME Bitwarden item as hempriser ("hempriser-minio") — same MinIO,
+# same keys — just remapped to the names AlphaOS expects (MINIO_ENDPOINT_URL / *_ACCESS_KEY_ID /
+# *_SECRET_ACCESS_KEY). The endpoint is non-secret (same s3-lan the dashboard uses) so it's a
+# literal; only the access/secret keys come from Bitwarden.
+# Attached to alphaos run pods ONLY, via the dagster-k8s/config env_from tag in marketdata/
+# dagster_defs.py (v0.5.1) — NOT in the global runLauncher.envSecrets (avoids cred spray).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-minio-rw
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: alphaos-minio-rw
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        MINIO_ENDPOINT_URL: "http://s3-lan.ekenhome.se:9000"
+        MINIO_ACCESS_KEY_ID: "{{ .MINIO_ACCESS_KEY }}"
+        MINIO_SECRET_ACCESS_KEY: "{{ .MINIO_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: hempriser-minio
+---
+# massive.com (Massive.com flatfile) S3 creds for alphaos run pods (market-data fetch source).
+# AlphaOS reads MASSIVE_S3_ACCESS_KEY_ID / MASSIVE_S3_SECRET_ACCESS_KEY.
+# TODO: create Bitwarden item "alphaos-massive" with fields
+#   MASSIVE_S3_ACCESS_KEY_ID, MASSIVE_S3_SECRET_ACCESS_KEY.
+# Attached to alphaos run pods ONLY, via the dagster-k8s/config env_from tag (v0.5.1).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-massive
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: alphaos-massive
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        MASSIVE_S3_ACCESS_KEY_ID: "{{ .MASSIVE_S3_ACCESS_KEY_ID }}"
+        MASSIVE_S3_SECRET_ACCESS_KEY: "{{ .MASSIVE_S3_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: alphaos-massive

--- a/kubernetes/apps/datasci/dagster/app/helmrelease.yaml
+++ b/kubernetes/apps/datasci/dagster/app/helmrelease.yaml
@@ -57,6 +57,9 @@ spec:
           - host: grid-reliance-pipeline.development.svc.cluster.local
             port: 4000
             name: grid-reliance-pipeline
+          - host: alphaos-pipeline.development.svc.cluster.local
+            port: 4000
+            name: alphaos-pipeline
     dagsterDaemon:
       checkDbReadyInitContainer: false
       annotations:

--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -33,11 +33,11 @@ spec:
         runAsGroup: 10001
         fsGroup: 10001
       initContainers:
-        # Migrate the Postgres schema before the app starts (alembic; currently up to 0005 —
-        # transactions ledger; positions are derived from it).
+        # Migrate the Postgres schema before the app starts (alembic; currently up to 0009 —
+        # derived NAV ledger; positions/NAV are derived from the transactions ledger).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:sha-e705a54
+          image: ghcr.io/ekenheim/alphaos:0.5.1
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -54,7 +54,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:sha-e705a54
+          image: ghcr.io/ekenheim/alphaos:0.5.1
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -71,7 +71,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:sha-e705a54
+          image: ghcr.io/ekenheim/alphaos:0.5.1
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
@@ -1,0 +1,72 @@
+---
+# Dagster code location (gRPC server on port 4000) for the AlphaOS market-data pipeline.
+# Register in Dagster UI at alphaos-pipeline.development.svc.cluster.local:4000.
+# The code server only loads definitions (marketdata.dagster_defs) — it does NOT need MinIO/
+# Massive creds to start. Those are required by the *run pods* (jobNamespace: datasci); see the
+# alphaos-minio-rw / alphaos-massive secrets scoped via the job's dagster-k8s/config tag.
+# Pin an explicit tag (NOT :latest — latest only tracks main, which is still 0.4.2).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alphaos-pipeline
+  namespace: development
+  labels:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alphaos
+      app.kubernetes.io/component: pipeline
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alphaos
+        app.kubernetes.io/component: pipeline
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: grpc
+          image: ghcr.io/ekenheim/alphaos:0.5.1
+          command:
+            ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "marketdata.dagster_defs"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          imagePullPolicy: Always
+          ports:
+            - name: grpc
+              containerPort: 4000
+              protocol: TCP
+          env:
+            - name: DAGSTER_HOME
+              value: "/tmp/dagster"
+            # Run pods inherit this image (K8sRunLauncher uses DAGSTER_CURRENT_IMAGE).
+            - name: DAGSTER_CURRENT_IMAGE
+              value: "ghcr.io/ekenheim/alphaos:0.5.1"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 10
+            periodSeconds: 5

--- a/kubernetes/apps/development/alphaos/app/pipeline/kustomization.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/kustomization.yaml
@@ -3,8 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./externalsecret.yaml
   - ./deployment.yaml
   - ./service.yaml
-  - ./ingress.yaml
-  - ./pipeline

--- a/kubernetes/apps/development/alphaos/app/pipeline/service.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/service.yaml
@@ -1,0 +1,21 @@
+---
+# Service for the AlphaOS Dagster gRPC code location
+# (alphaos-pipeline.development.svc.cluster.local:4000).
+apiVersion: v1
+kind: Service
+metadata:
+  name: alphaos-pipeline
+  namespace: development
+  labels:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: pipeline
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: 4000
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alphaos
+    app.kubernetes.io/component: pipeline


### PR DESCRIPTION
## What

Wires the new AlphaOS market-data Dagster pipeline into the cluster and rolls AlphaOS to **v0.5.1**.

- **Code location**: `alphaos-pipeline` registered in `dagster` `workspace.servers`.
- **gRPC code server**: new `Deployment` + `Service` in `development` (`marketdata.dagster_defs`, port 4000), image `ghcr.io/ekenheim/alphaos:0.5.1`, `DAGSTER_CURRENT_IMAGE=0.5.1` so run pods inherit it.
- **Dashboard**: bumped to `0.5.1`; alembic migration **0008 → 0009** runs via the existing `db-migrate` initContainer.
- **Run-pod secrets** (`datasci` ns): `alphaos-minio-rw` (reuses the `hempriser-minio` Bitwarden item) + `alphaos-massive` (new Bitwarden item). Attached to AlphaOS run pods **only** via the `dagster-k8s/config` `env_from` job tag (v0.5.1) — deliberately **not** in global `runLauncher.envSecrets`, to avoid spraying write creds to other pipelines' run pods.

## Post-merge

1. Flux reconciles → `alphaos-pipeline` pulls `0.5.1`, code location loads.
2. Start `market_data_daily_schedule` in the Dagster UI (lands stopped; daily 07:00 UTC).

## Confirm with alphaos dev

The `dagster-k8s/config` tag should `env_from` **both** `alphaos-minio-rw` and `alphaos-massive`, set `MINIO_BUCKET=stocks-us`, and provide the **Massive endpoint URL + bucket** (not present in ops manifests — only the two Massive keys are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)