### PR TITLE
chore(alphaos): update to 0.6.0

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -33,11 +33,12 @@ spec:
         runAsGroup: 10001
         fsGroup: 10001
       initContainers:
-        # Migrate the Postgres schema before the app starts (alembic; currently up to 0009 —
-        # derived NAV ledger; positions/NAV are derived from the transactions ledger).
+        # Migrate the Postgres schema before the app starts (alembic; currently up to 0010 —
+        # fx_rates + sleeve_weight_history tables; reserve/planning_cagr columns dropped.
+        # Existing data is untouched; the db-seed step below is bootstrap-once (won't reset sleeves).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:0.5.2
+          image: ghcr.io/ekenheim/alphaos:0.6.0
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -54,7 +55,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:0.5.2
+          image: ghcr.io/ekenheim/alphaos:0.6.0
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -71,7 +72,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:0.5.2
+          image: ghcr.io/ekenheim/alphaos:0.6.0
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: grpc
-          image: ghcr.io/ekenheim/alphaos:0.5.2
+          image: ghcr.io/ekenheim/alphaos:0.6.0
           command:
             ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "marketdata.dagster_defs"]
           securityContext:
@@ -52,7 +52,7 @@ spec:
               value: "/tmp/dagster"
             # Run pods inherit this image (K8sRunLauncher uses DAGSTER_CURRENT_IMAGE).
             - name: DAGSTER_CURRENT_IMAGE
-              value: "ghcr.io/ekenheim/alphaos:0.5.2"
+              value: "ghcr.io/ekenheim/alphaos:0.6.0"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Bumps AlphaOS `0.5.2` → `0.6.0` (dashboard + init containers + `alphaos-pipeline` code location, image & `DAGSTER_CURRENT_IMAGE`).

**Migration 0010** runs automatically via the `db-migrate` initContainer (`alphaos db upgrade`): creates `fx_rates` + `sleeve_weight_history`, drops the `external_reserve`/`planning_cagr_*` columns. Existing data untouched; `db-seed` is bootstrap-once so sleeves aren't reset.

Includes the five dashboard refinements: FX history, reserve removal, computed CAGR + % growth, editable holdings history, user-managed sleeves.

Verified `ghcr.io/ekenheim/alphaos:0.6.0` is present on GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)