### PR TITLE
feat(datasci): add litellm, agentmemory and hermes LLM stack

### DIFF
--- a/kubernetes/apps/datasci/agentmemory/app/externalsecret.yaml
+++ b/kubernetes/apps/datasci/agentmemory/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name agentmemory
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: Helm
+        annotations:
+          meta.helm.sh/release-name: agentmemory
+          meta.helm.sh/release-namespace: datasci
+      data:
+        # Embeddings go direct to ollama-igpu, which needs no real key.
+        OPENAI_API_KEY: "ollama"
+        # LLM-enrichment calls go to litellm (Anthropic-compatible), which
+        # authenticates with the litellm master key.
+        ANTHROPIC_API_KEY: '{{ .LITELLM_MASTER_KEY }}'
+        # App signing/session secret — store this field in the `agentmemory`
+        # Bitwarden Secrets Manager item. Shared with hermes' plugin bearer.
+        AGENTMEMORY_SECRET: '{{ .AGENTMEMORY_SECRET }}'
+  dataFrom:
+    - extract:
+        key: agentmemory
+    - extract:
+        key: litellm

--- a/kubernetes/apps/datasci/agentmemory/app/helmrelease.yaml
+++ b/kubernetes/apps/datasci/agentmemory/app/helmrelease.yaml
@@ -1,0 +1,162 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app agentmemory
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      agentmemory:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/joryirving/agentmemory
+              tag: 0.9.27@sha256:3dbd28e1194f9e36babef9f8611ee10b5673444aed8df8b74144c3ba91073e48
+            command:
+              - /usr/bin/catatonit
+              - --
+              - /bin/sh
+              - -c
+              - |
+                PREFS_HOME="${HOME:-/home/node}"
+                mkdir -p "$PREFS_HOME/.agentmemory"
+                if [ ! -s "$PREFS_HOME/.agentmemory/preferences.json" ]; then
+                  printf '%s\n' '{"schemaVersion":1,"lastAgent":null,"lastAgents":[],"lastProvider":null,"skipSplash":true,"skipNpxHint":true,"skipGlobalInstall":true,"skipConsoleInstall":true,"firstRunAt":"1970-01-01T00:00:00.000Z"}' > "$PREFS_HOME/.agentmemory/preferences.json"
+                fi
+                exec /entrypoint.sh
+            env:
+              AGENTMEMORY_DROP_STALE_INDEX: "true"
+              AGENTMEMORY_TOOLS: "all"
+              AGENTMEMORY_LLM_TIMEOUT_MS: "120000"
+              # --- Embeddings: ollama-igpu (OpenAI-compatible /v1) ---
+              EMBEDDING_PROVIDER: "openai"
+              OPENAI_BASE_URL: "http://ollama-igpu.datasci:11434/v1"
+              OPENAI_API_KEY_FOR_LLM: "false"
+              OPENAI_EMBEDDING_MODEL: "all-minilm"
+              OPENAI_EMBEDDING_DIMENSIONS: "384"
+              # --- LLM enrichment via litellm (Anthropic-compatible endpoint).
+              # litellm translates Anthropic Messages calls to the `review` alias.
+              CONSOLIDATION_ENABLED: "true"
+              GRAPH_EXTRACTION_ENABLED: "true"
+              AGENTMEMORY_AUTO_COMPRESS: "true"
+              ANTHROPIC_BASE_URL: "http://litellm.datasci:4000"
+              ANTHROPIC_MODEL: "review"
+              # --- Server / viewer ---
+              III_REST_PORT: "3111"
+              RUST_LOG: "warn"
+              VIEWER_ALLOWED_HOSTS: "agentmemory.${SECRET_DOMAIN}"
+              VIEWER_ALLOWED_ORIGINS: "https://agentmemory.${SECRET_DOMAIN}"
+              TZ: "${TIMEZONE}"
+            envFrom:
+              - secretRef:
+                  name: agentmemory
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 60
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        controller: *app
+        ports:
+          api:
+            port: 3111
+          stream:
+            port: 3112
+          viewer:
+            port: 3113
+    ingress:
+      app:
+        className: internal
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Data Science
+          gethomepage.dev/name: AgentMemory
+          gethomepage.dev/icon: mdi-brain
+          gethomepage.dev/description: Long-term memory service for agents
+          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+          nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+        hosts:
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: viewer
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/datasci/agentmemory/app/kustomization.yaml
+++ b/kubernetes/apps/datasci/agentmemory/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/guarded
+  - ../../../../templates/volsync

--- a/kubernetes/apps/datasci/agentmemory/ks.yaml
+++ b/kubernetes/apps/datasci/agentmemory/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.minuette.horse/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentmemory
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/datasci/agentmemory/app
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: datasci
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  dependsOn:
+    - name: volsync
+    - name: external-secrets-stores
+    - name: rook-ceph-cluster
+    - name: litellm
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/datasci/hermes/app/agentmemory-plugin.yaml
+++ b/kubernetes/apps/datasci/hermes/app/agentmemory-plugin.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agentmemory-plugin
+data:
+  plugin.yaml: |
+    name: agentmemory
+    version: 0.9.21
+    description: "Persistent cross-session memory for Hermes Agent via agentmemory."
+    author: "Rohit Ghumare"
+    homepage: "https://github.com/rohitg00/agentmemory"
+    hooks:
+      - on_session_end
+      - on_pre_compress
+      - on_memory_write
+  __init__.py: |
+    from __future__ import annotations
+
+    import json
+    import os
+    import sys
+    import threading
+    import time
+    from typing import Any, Callable
+    from urllib.error import URLError
+    from urllib.parse import urlparse
+    from urllib.request import Request, urlopen
+
+    try:
+        from agent.memory_provider import MemoryProvider
+    except ImportError:
+        from abc import ABC, abstractmethod
+
+        class MemoryProvider(ABC):
+            @property
+            @abstractmethod
+            def name(self) -> str: ...
+            @abstractmethod
+            def is_available(self) -> bool: ...
+            @abstractmethod
+            def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+            @abstractmethod
+            def get_tool_schemas(self) -> list[dict]: ...
+            @abstractmethod
+            def handle_tool_call(self, name: str, args: dict) -> str: ...
+            def system_prompt_block(self) -> str: return ""
+            def prefetch(self, query: str, **kwargs: Any) -> str: return ""
+            def queue_prefetch(self, query: str, **kwargs: Any) -> None: pass
+            def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None: pass
+            def on_session_end(self, messages: list, **kwargs: Any) -> None: pass
+            def on_pre_compress(self, messages: list, **kwargs: Any) -> None: pass
+            def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None: pass
+            def shutdown(self, **kwargs: Any) -> None: pass
+
+
+    DEFAULT_BASE_URL = "http://agentmemory.llm:3111"
+    DEFAULT_PROJECT = "hermes"
+    TIMEOUT = 5
+    LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+    _plaintext_bearer_warned = False
+
+
+    def _validate_url(base: str) -> bool:
+        if not base:
+            return False
+        try:
+            parsed = urlparse(base)
+            _ = parsed.port
+        except ValueError:
+            return False
+        return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
+    def _uses_plaintext_bearer_auth(base: str, secret: str = "") -> bool:
+        if not secret:
+            return False
+        parsed = urlparse(base)
+        return parsed.scheme == "http" and (parsed.hostname or "").lower() not in LOOPBACK_HOSTS
+
+
+    def _check_plaintext_bearer_guard(base: str, secret: str = "", warn: Callable[[str], None] | None = None) -> None:
+        global _plaintext_bearer_warned
+        if not _uses_plaintext_bearer_auth(base, secret):
+            return
+        message = f"agentmemory: AGENTMEMORY_SECRET is configured for plaintext HTTP to {base}."
+        if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
+            raise RuntimeError(message)
+        if not _plaintext_bearer_warned:
+            _plaintext_bearer_warned = True
+            (warn or (lambda msg: print(msg, file=sys.stderr)))(message)
+
+
+    def _api(base: str, path: str, body: dict | None = None, method: str = "POST") -> dict | None:
+        if not _validate_url(base):
+            return None
+        secret = os.environ.get("AGENTMEMORY_SECRET", "")
+        _check_plaintext_bearer_guard(base, secret)
+        headers = {"Content-Type": "application/json"}
+        if secret:
+            headers["Authorization"] = f"Bearer {secret}"
+        req = Request(
+            f"{base.rstrip('/')}/agentmemory/{path}",
+            data=json.dumps(body).encode() if body else None,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urlopen(req, timeout=TIMEOUT) as resp:
+                return json.loads(resp.read().decode())
+        except (URLError, TimeoutError, json.JSONDecodeError):
+            return None
+
+
+    def _api_bg(base: str, path: str, body: dict | None = None) -> None:
+        threading.Thread(target=_api, args=(base, path, body), daemon=True).start()
+
+
+    class AgentMemoryProvider(MemoryProvider):
+        @property
+        def name(self) -> str:
+            return "agentmemory"
+
+        def is_available(self) -> bool:
+            return _validate_url(os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL))
+
+        def initialize(self, session_id: str, **kwargs: Any) -> None:
+            self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
+            self._project = os.environ.get("AGENTMEMORY_PROJECT", DEFAULT_PROJECT)
+            self._cwd = kwargs.get("cwd") or os.environ.get("HERMES_HOME") or os.getcwd()
+            self._session_id = f"{self._project}:{session_id}"
+            _api(self._base, "session/start", {
+                "sessionId": self._session_id,
+                "project": self._project,
+                "cwd": self._cwd,
+            })
+
+        def system_prompt_block(self) -> str:
+            result = _api(self._base, "context", {
+                "sessionId": self._session_id,
+                "project": self._project,
+            })
+            return result.get("context", "") if result else ""
+
+        def prefetch(self, query: str, **kwargs: Any) -> str:
+            result = _api(self._base, "search", {
+                "project": self._project,
+                "query": query,
+                "limit": 5,
+            })
+            lines = []
+            for item in (result or {}).get("results", [])[:5]:
+                obs = item.get("observation", item)
+                title = obs.get("title", "")
+                narrative = obs.get("narrative", "")
+                if title:
+                    lines.append(f"- {title}: {narrative[:200]}")
+            return "\n".join(lines)
+
+        def queue_prefetch(self, query: str, **kwargs: Any) -> None:
+            _api_bg(self._base, "search", {
+                "project": self._project,
+                "query": query,
+                "limit": 3,
+            })
+
+        def get_tool_schemas(self) -> list[dict]:
+            return [
+                {
+                    "name": "memory_recall",
+                    "description": "Search Hermes-scoped agentmemory observations.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "limit": {"type": "integer", "default": 10},
+                        },
+                        "required": ["query"],
+                    },
+                },
+                {
+                    "name": "memory_save",
+                    "description": "Save a Hermes-scoped long-term memory.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "type": {"type": "string", "default": "fact"},
+                        },
+                        "required": ["content"],
+                    },
+                },
+            ]
+
+        def handle_tool_call(self, name: str, args: dict) -> str:
+            if name == "memory_recall":
+                result = _api(self._base, "search", {
+                    "project": self._project,
+                    "query": args["query"],
+                    "limit": args.get("limit", 10),
+                })
+                return json.dumps({"results": (result or {}).get("results", [])})
+
+            if name == "memory_save":
+                result = _api(self._base, "observe", self._observation_payload(
+                    args["content"],
+                    "",
+                    args.get("type", "fact"),
+                ))
+                return json.dumps({"success": result is not None})
+
+            return json.dumps({"error": f"Unknown tool: {name}"})
+
+        def _observation_payload(self, tool_input: str, tool_output: str, memory_type: str = "conversation") -> dict:
+            return {
+                "hookType": "post_tool_use",
+                "sessionId": self._session_id,
+                "project": self._project,
+                "cwd": self._cwd,
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "data": {
+                    "tool_name": memory_type,
+                    "tool_input": tool_input[:1000],
+                    "tool_output": tool_output[:4000],
+                },
+            }
+
+        def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
+            _api_bg(self._base, "observe", self._observation_payload(user, assistant))
+
+        def on_session_end(self, messages: list, **kwargs: Any) -> None:
+            _api(self._base, "session/end", {"sessionId": self._session_id})
+
+        def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
+            context = self.system_prompt_block()
+            if context:
+                messages.insert(0, {
+                    "role": "user",
+                    "content": f"[agentmemory context before compaction]\n{context}",
+                })
+
+        def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
+            if action in ("add", "update") and content:
+                _api_bg(self._base, "observe", self._observation_payload(content, "", "memory_write"))
+
+        def shutdown(self, **kwargs: Any) -> None:
+            pass
+
+
+    def register(ctx: Any) -> None:
+        ctx.register_memory_provider(AgentMemoryProvider())

--- a/kubernetes/apps/datasci/hermes/app/configmap.yaml
+++ b/kubernetes/apps/datasci/hermes/app/configmap.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-config
+data:
+  config.yaml: |
+    model:
+      default: self-hosted
+      provider: litellm-anthropic
+    fallback_providers:
+      - provider: litellm
+        model: self-hosted
+    providers:
+      litellm:
+        base_url: http://litellm.datasci:4000/v1
+        api_key: $${LITELLM_API_KEY}
+      litellm-anthropic:
+        base_url: http://litellm.datasci:4000/
+        api_mode: anthropic_messages
+        api_key: $${LITELLM_API_KEY}
+    toolsets:
+      - hermes-cli
+    terminal:
+      backend: local
+      cwd: /opt/data/workspace
+      timeout: 180
+      persistent_shell: true
+    memory:
+      provider: agentmemory
+      auto_migrate: true
+    compression:
+      enabled: true
+      threshold: 0.50
+      target_ratio: 0.20
+      protect_last_n: 20
+    agent:
+      max_turns: 90
+      gateway_timeout: 1800
+      restart_drain_timeout: 60
+      api_max_retries: 2
+      reasoning_effort: medium
+    streaming:
+      enabled: false
+    security:
+      redact_secrets: true
+    privacy:
+      redact_pii: true
+    platform_toolsets:
+      cli:
+        - hermes-cli
+    # mcp_servers:
+    #   # TODO: toolhive exposes each MCPServer as its own in-cluster service
+    #   # (there is no single vmcp gateway here like jory's). Verify the name/port:
+    #   #   kubectl -n datasci get svc | grep mcp
+    #   # then point hermes at it, e.g.:
+    #   toolhive:
+    #     url: http://mcp-ha-mcp.datasci:8080/mcp
+    auxiliary:
+      vision:
+        provider: litellm-anthropic
+        model: self-hosted
+      compression:
+        provider: litellm
+        model: self-hosted
+        timeout: 180
+      web_extract:
+        provider: litellm
+        model: self-hosted
+        timeout: 120
+      approval:
+        provider: litellm
+        model: self-hosted
+        timeout: 60
+      session_search:
+        provider: litellm
+        model: self-hosted
+        timeout: 120

--- a/kubernetes/apps/datasci/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/datasci/hermes/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name hermes
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: Helm
+        annotations:
+          meta.helm.sh/release-name: hermes
+          meta.helm.sh/release-namespace: datasci
+      data:
+        # Proxy key for hermes -> litellm (same value as litellm's master key).
+        LITELLM_API_KEY: '{{ .LITELLM_MASTER_KEY }}'
+        # Bearer token for the agentmemory plugin -> agentmemory service.
+        # Must match agentmemory's AGENTMEMORY_SECRET.
+        AGENTMEMORY_SECRET: '{{ .AGENTMEMORY_SECRET }}'
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: agentmemory

--- a/kubernetes/apps/datasci/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/datasci/hermes/app/helmrelease.yaml
@@ -1,0 +1,181 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hermes
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.24"
+            command:
+              - sh
+              - -c
+              - |
+                set -euo pipefail
+                cp /tmp/config.yaml /opt/data/config.yaml
+                chown 10000:10000 /opt/data/config.yaml
+                PLUGIN_DIR=/opt/data/plugins/agentmemory
+                mkdir -p "$PLUGIN_DIR"
+                cp /tmp/agentmemory-plugin/plugin.yaml "$PLUGIN_DIR/plugin.yaml"
+                cp /tmp/agentmemory-plugin/__init__.py "$PLUGIN_DIR/__init__.py"
+                chown -R 10000:10000 /opt/data/plugins
+        containers:
+          app:
+            image: &image
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+            args: ["gateway", "run", "--no-supervise"]
+            env:
+              HERMES_HOME: /opt/data
+              HOME: /opt/data
+              TZ: "${TIMEZONE}"
+              AGENTMEMORY_URL: http://agentmemory.datasci:3111
+              AGENTMEMORY_PROJECT: hermes
+              AGENTMEMORY_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes
+                    key: AGENTMEMORY_SECRET
+            envFrom:
+              - secretRef:
+                  name: hermes
+            resources:
+              requests:
+                cpu: 500m
+              limits:
+                memory: 2Gi
+            ports:
+              - name: http
+                containerPort: 8642
+                protocol: TCP
+              - name: codeserver
+                containerPort: 12321
+                protocol: TCP
+          dashboard:
+            image: *image
+            args:
+              - dashboard
+              - --host
+              - "0.0.0.0"
+              - --insecure
+            env:
+              TZ: "${TIMEZONE}"
+              GATEWAY_HEALTH_URL: http://localhost:8642
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 1Gi
+            ports:
+              - name: http
+                containerPort: 9119
+                protocol: TCP
+          codeserver:
+            image:
+              repository: ghcr.io/coder/code-server
+              tag: 4.123.0@sha256:6d46b83ea0687ab1826ec029b6d0e6342bbd55cc5c29b98258463e7faee16d1e
+            args:
+              - --auth
+              - none
+              - --user-data-dir
+              - /home/node/.vscode
+              - --extensions-dir
+              - /home/node/.vscode
+              - --port
+              - "12321"
+              - /opt/data
+            env:
+              TZ: "${TIMEZONE}"
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 8642
+          codeserver:
+            port: 12321
+      dashboard:
+        controller: *app
+        ports:
+          http:
+            port: 9119
+    ingress:
+      app:
+        className: internal
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Data Science
+          gethomepage.dev/name: Hermes
+          gethomepage.dev/icon: mdi-robot
+          gethomepage.dev/description: Hermes agent gateway
+          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hosts:
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: dashboard
+                  port: http
+      code:
+        className: internal
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hosts:
+          - host: "{{ .Release.Name }}-code.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: codeserver
+    persistence:
+      config:
+        existingClaim: *app
+        globalMounts:
+          - path: /opt/data
+      configmap:
+        type: configMap
+        name: hermes-config
+        defaultMode: 0755
+        globalMounts:
+          - path: /tmp/config.yaml
+            subPath: config.yaml
+      plugin:
+        type: configMap
+        name: hermes-agentmemory-plugin
+        globalMounts:
+          - path: /tmp/agentmemory-plugin

--- a/kubernetes/apps/datasci/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/datasci/hermes/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./agentmemory-plugin.yaml
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/guarded
+  - ../../../../templates/volsync

--- a/kubernetes/apps/datasci/hermes/ks.yaml
+++ b/kubernetes/apps/datasci/hermes/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.minuette.horse/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/datasci/hermes/app
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: datasci
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  dependsOn:
+    - name: volsync
+    - name: external-secrets-stores
+    - name: rook-ceph-cluster
+    - name: litellm
+    - name: agentmemory
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/datasci/kustomization.yaml
+++ b/kubernetes/apps/datasci/kustomization.yaml
@@ -21,6 +21,9 @@ resources:
   - ./grid-reliance-infra/ks.yaml
   - ./ollama-igpu/ks.yaml
   - ./open-webui/ks.yaml
+  - ./litellm/ks.yaml
+  - ./agentmemory/ks.yaml
+  - ./hermes/ks.yaml
   # DISABLED: stale entry — open-webui tool gather times out on /sse, breaks
   # chats that touch any tool server. Re-enable only after registering it
   # in open-webui as Type: MCP (not OpenAPI) and verifying the handshake.

--- a/kubernetes/apps/datasci/litellm/app/configmap.yaml
+++ b/kubernetes/apps/datasci/litellm/app/configmap.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-configmap
+data:
+  config.yaml: |
+    model_list:
+      # --- Self-hosted via ollama-igpu (OpenAI-compatible /v1) ---
+      # NOTE: the `llama3.1` model below must be pulled in ollama-igpu
+      # (`ollama pull llama3.1`) or swapped for a model you have.
+      - model_name: self-hosted
+        model_info:
+          mode: chat
+          supports_function_calling: true
+        litellm_params:
+          model: openai/llama3.1
+          api_base: http://ollama-igpu.datasci:11434/v1
+          api_key: ollama
+
+      # `review` is the alias agentmemory points ANTHROPIC_MODEL at.
+      - model_name: review
+        model_info:
+          mode: chat
+          supports_function_calling: true
+        litellm_params:
+          model: openai/llama3.1
+          api_base: http://ollama-igpu.datasci:11434/v1
+          api_key: ollama
+
+      - model_name: all-minilm
+        model_info:
+          mode: embedding
+        litellm_params:
+          model: openai/all-minilm
+          api_base: http://ollama-igpu.datasci:11434/v1
+          api_key: ollama
+
+      # --- Cloud providers (placeholders) ---
+      # Add the matching keys to the `litellm` Bitwarden item + externalsecret,
+      # then uncomment. See jory's repo for the full reference set.
+      # - model_name: MiniMax
+      #   model_info:
+      #     mode: messages
+      #     supports_function_calling: true
+      #     supports_vision: true
+      #   litellm_params:
+      #     model: minimax/MiniMax-M3
+      #     api_base: https://api.minimax.io/anthropic/v1/messages
+      #     api_key: os.environ/MINIMAX_API_KEY
+
+    general_settings:
+      health_check_endpoint: /v1/health
+
+    router_settings:
+      enable_pre_call_checks: true
+      fallbacks:
+        - review: ["self-hosted"]
+
+    litellm_settings:
+      drop_params: true
+      request_timeout: 600
+      num_retries: 2
+      set_verbose: false

--- a/kubernetes/apps/datasci/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/datasci/litellm/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name litellm
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: Helm
+        annotations:
+          meta.helm.sh/release-name: litellm
+          meta.helm.sh/release-namespace: datasci
+      data:
+        # Proxy master key — clients (agentmemory, hermes) authenticate with this.
+        LITELLM_MASTER_KEY: '{{ .LITELLM_MASTER_KEY }}'
+        # --- Cloud upstream keys: add the fields to the `litellm` Bitwarden item
+        # and uncomment as you enable the matching model_list entries in config.yaml.
+        # MINIMAX_API_KEY: '{{ .MINIMAX_API_KEY }}'
+        # MOONSHOT_API_KEY: '{{ .MOONSHOT_API_KEY }}'
+        # OPENAI_API_KEY: '{{ .OPENAI_API_KEY }}'
+        # ANTHROPIC_API_KEY: '{{ .ANTHROPIC_API_KEY }}'
+  dataFrom:
+    - extract:
+        key: litellm

--- a/kubernetes/apps/datasci/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/datasci/litellm/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app litellm
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: v1.89.0@sha256:66a108711edea25ef531a74764f001d0c1934cc8abb422f5a3bd17a2860e4035
+            args:
+              - --config=/app/config.yaml
+            env:
+              LITELLM_LOG: INFO
+              LITELLM_MODE: PRODUCTION
+              TZ: "${TIMEZONE}"
+            envFrom:
+              - secretRef:
+                  name: litellm
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/liveliness
+                    port: 4000
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/readiness
+                    port: 4000
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 3
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 4000
+    ingress:
+      app:
+        className: internal
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Data Science
+          gethomepage.dev/name: LiteLLM
+          gethomepage.dev/icon: litellm.png
+          gethomepage.dev/description: LLM proxy / gateway
+          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hosts:
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        type: configMap
+        name: litellm-configmap
+        globalMounts:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/cache

--- a/kubernetes/apps/datasci/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/datasci/litellm/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/guarded

--- a/kubernetes/apps/datasci/litellm/ks.yaml
+++ b/kubernetes/apps/datasci/litellm/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.minuette.horse/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/datasci/litellm/app
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: datasci
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  dependsOn:
+    - name: external-secrets-stores
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
Adds three coupled LLM apps to the `datasci` namespace, adapted from [joryirving/home-ops](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/llm) to our cluster (his target infra — `litellm.llm`, `memini`, `llama-embed`, his NAS, paid providers — doesn't exist here).

## Apps
- **litellm** (`litellm.datasci:4000`) — berriai/litellm proxy, single replica, no Redis/dragonfly. `model_list` backed by `ollama-igpu`; stable aliases `self-hosted`/`review`/`all-minilm`; cloud models commented as placeholders.
- **agentmemory** (`agentmemory.datasci:3111`) — embeddings direct to ollama-igpu; LLM-enrichment (consolidation/graph/compress) via litellm `review` alias.
- **hermes** — hermes-agent + dashboard + code-server sidecars; uses litellm and the **agentmemory plugin** (verbatim ConfigMap) as memory backend. memini/NAS dropped.

## Wiring
```
hermes ─(litellm-anthropic)─┐
                            ├─> litellm.datasci:4000 ─> ollama-igpu (llama3.1)
agentmemory ─(enrichment)───┘
agentmemory ─(embeddings)──────> ollama-igpu (all-minilm, direct)
hermes ─(agentmemory plugin)───> agentmemory.datasci:3111
```

## ⚠️ Manual prerequisites before these go healthy
1. **Bitwarden Secrets Manager** items: `litellm` → `LITELLM_MASTER_KEY`; `agentmemory` → `AGENTMEMORY_SECRET` (shared with hermes' plugin bearer).
2. **ollama**: pull `llama3.1` and `all-minilm` (or change the model names in litellm config + agentmemory embedding env).
3. **toolhive MCP**: hermes `mcp_servers` left commented — no vmcp gateway here, only per-MCPServer services; verify `kubectl -n datasci get svc | grep mcp` before wiring.

ollama-igpu is intentionally retained — it is litellm's model backend (and open-webui's/openclaw's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)