### PR TITLE
fix(alphaos): give Dagster code server its metadata DB creds

### DIFF
--- a/kubernetes/apps/development/alphaos/app/externalsecret.yaml
+++ b/kubernetes/apps/development/alphaos/app/externalsecret.yaml
@@ -54,3 +54,36 @@ spec:
   dataFrom:
     - extract:
         key: postgres-pguser-alphaos
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# Dagster's OWN run/event/schedule storage (the SHARED "dagster" metadata DB), NOT the alphaos
+# app DB above. The alphaos-pipeline gRPC code server needs these DAGSTER_PG_* vars to build a
+# DagsterInstance when evaluating schedule ticks; without them schedule evaluation fails with
+# "DAGSTER_PG_PASSWORD not set". Sourced from postgres-pguser-dagster so the code server reads
+# the same storage as the dagster webserver/daemon (datasci). Mirrors hempriser-dagster-db.
+# Direct primary (not PgBouncer) to avoid SCRAM-SHA-256 SASL failures on Dagster schema mgmt.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alphaos-dagster-db
+  namespace: development
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: crunchy-pgo-secrets
+    kind: ClusterSecretStore
+  target:
+    name: alphaos-dagster-db
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      data:
+        DAGSTER_PG_HOST: '{{ .host }}'
+        DAGSTER_PG_PORT: '{{ .port }}'
+        DAGSTER_PG_DB_NAME: '{{ .dbname }}'
+        DAGSTER_PG_USER: '{{ .user }}'
+        DAGSTER_PG_PASSWORD: '{{ .password }}'
+  dataFrom:
+    - extract:
+        key: postgres-pguser-dagster

--- a/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
@@ -47,12 +47,18 @@ spec:
             - name: grpc
               containerPort: 4000
               protocol: TCP
+          # Dagster's metadata DB (DAGSTER_PG_*) — needed so the code server can build a
+          # DagsterInstance when evaluating schedule ticks. Points at the SHARED "dagster" DB,
+          # not the alphaos app DB. Run pods get app DB/MinIO via the dagster-k8s/config tag.
+          envFrom:
+            - secretRef:
+                name: alphaos-dagster-db
           env:
             - name: DAGSTER_HOME
               value: "/tmp/dagster"
             # Run pods inherit this image (K8sRunLauncher uses DAGSTER_CURRENT_IMAGE).
             - name: DAGSTER_CURRENT_IMAGE
-              value: "ghcr.io/ekenheim/alphaos:0.6.0"
+              value: "ghcr.io/ekenheim/alphaos:0.6.1"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Problem

The `alphaos-pipeline` gRPC code server crashed during schedule-tick evaluation with:

```
dagster._config.errors.PostProcessingError: You have attempted to fetch the
environment variable "DAGSTER_PG_PASSWORD" which is not set.
```

Evaluating a schedule tick builds a `DagsterInstance` from the instance ref, which reads the `dagster.yaml` baked into the image and resolves Postgres storage from `DAGSTER_PG_*` env vars. The deployment only set `DAGSTER_HOME`/`DAGSTER_CURRENT_IMAGE`, so the lookup failed.

This is Dagster's **shared run/event/schedule metadata DB** (the `dagster` database), *not* the AlphaOS app DB — so the code server must read the same storage as the webserver/daemon in `datasci`.

## Fix

- Add `alphaos-dagster-db` ExternalSecret sourced from `postgres-pguser-dagster`, exposing `DAGSTER_PG_HOST/PORT/DB_NAME/USER/PASSWORD` (direct primary, not PgBouncer — SCRAM-SHA-256). Mirrors `hempriser-dagster-db`.
- Inject it via `envFrom` on the `alphaos-pipeline` code server.
- Bump `DAGSTER_CURRENT_IMAGE` `0.6.0` → `0.6.1` to match the running image.

## Note

Env var names match `hempriser-dagster-db`. The error only proves `DAGSTER_PG_PASSWORD`; if the pod still errors after the secret lands, check whether the image's `dagster.yaml` expects `DAGSTER_PG_DB` instead of `DAGSTER_PG_DB_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)