### PR TITLE
chore(alphaos): bump image 0.6.1 → 0.6.2

### DIFF
--- a/kubernetes/apps/development/alphaos/app/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         # Existing data is untouched; the db-seed step below is bootstrap-once (won't reset sleeves).
         # Uses the DIRECT primary uri (DATABASE_URL) — DDL must not go through PgBouncer.
         - name: db-migrate
-          image: ghcr.io/ekenheim/alphaos:0.6.1
+          image: ghcr.io/ekenheim/alphaos:0.6.2
           command: ["alphaos", "db", "upgrade"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -55,7 +55,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
         # Idempotent seed of the 5 sleeves.
         - name: db-seed
-          image: ghcr.io/ekenheim/alphaos:0.6.1
+          image: ghcr.io/ekenheim/alphaos:0.6.2
           command: ["alphaos", "db", "seed"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -72,7 +72,7 @@ spec:
             limits: { cpu: 500m, memory: 512Mi }
       containers:
         - name: app
-          image: ghcr.io/ekenheim/alphaos:0.6.1
+          image: ghcr.io/ekenheim/alphaos:0.6.2
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
+++ b/kubernetes/apps/development/alphaos/app/pipeline/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: grpc
-          image: ghcr.io/ekenheim/alphaos:0.6.1
+          image: ghcr.io/ekenheim/alphaos:0.6.2
           command:
             ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "marketdata.dagster_defs"]
           securityContext:
@@ -58,7 +58,7 @@ spec:
               value: "/tmp/dagster"
             # Run pods inherit this image (K8sRunLauncher uses DAGSTER_CURRENT_IMAGE).
             - name: DAGSTER_CURRENT_IMAGE
-              value: "ghcr.io/ekenheim/alphaos:0.6.1"
+              value: "ghcr.io/ekenheim/alphaos:0.6.2"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Bumps the AlphaOS image `0.6.1` → `0.6.2` across both deployments:

- App deployment (main container + `db upgrade`/`db seed` initContainers)
- Pipeline code server (`image` + `DAGSTER_CURRENT_IMAGE` so run pods match)

Follow-up to #5740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)