### PR TITLE
fix(flux): resolve envsubst failures for nginx-external and nfs-stale-watchdog

### DIFF
--- a/kubernetes/apps/kube-tools/nfs-stale-watchdog/cronjob.yaml
+++ b/kubernetes/apps/kube-tools/nfs-stale-watchdog/cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   # StatefulSet pods (stable names) where a stale event from
                   # 40min ago could otherwise nuke a healthy replacement.
                   LOOKBACK_MIN=15
-                  CUTOFF_EPOCH=$(date -u -d "${LOOKBACK_MIN} minutes ago" +%s)
+                  CUTOFF_EPOCH=$(date -u -d "$${LOOKBACK_MIN} minutes ago" +%s)
 
                   TMPL='{range .items[*]}{.metadata.namespace}|{.involvedObject.kind}|{.involvedObject.name}|{.lastTimestamp}|{.message}{"\n"}{end}'
 

--- a/kubernetes/apps/network/nginx/external/helmrelease.yaml
+++ b/kubernetes/apps/network/nginx/external/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: |
             external.${SECRET_DOMAIN}
-            external.${SECRET_SECOND_DOMAIN}
+            external.${SECRET_SECONDARY_DOMAIN}
           io.cilium/lb-ipam-ips: 192.168.50.153
         externalTrafficPolicy: Cluster
       ingressClassResource:


### PR DESCRIPTION
## What

Two independent Flux `postBuild` envsubst (strict mode) failures were leaving Kustomizations stuck at `Ready: False`:

1. **`nginx-external`** — `HelmRelease` referenced `${SECRET_SECOND_DOMAIN}`, a **typo unique to this one file**. Every other consumer (cert-manager issuers/certificates, cloudflared, external-dns, strapi, marketing-agency) uses the canonical **`SECRET_SECONDARY_DOMAIN`**, which is already defined in `cluster-secrets.sops.yaml`. Fixed the reference to the correct name — no secret changes needed, and the real value stays encrypted (only the variable is referenced).

2. **`nfs-stale-watchdog`** — `${LOOKBACK_MIN}` is a **bash variable inside the CronJob script**, not a Flux substitution var. envsubst was trying to expand it and failing strict mode. Escaped it as `$${LOOKBACK_MIN}` so Flux renders it back to a literal `${LOOKBACK_MIN}` for the shell.

## Verification

- No plaintext domain value in the working tree — only the `${SECRET_SECONDARY_DOMAIN}` reference is used; the value remains SOPS-encrypted.
- Zero remaining `SECRET_SECOND_DOMAIN` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)