### PR TITLE
fix(flux): resolve envsubst failures for grafana, kubeflow-common, immich

### DIFF
--- a/kubernetes/apps/datasci/kubeflow/ks.yaml
+++ b/kubernetes/apps/datasci/kubeflow/ks.yaml
@@ -5,6 +5,13 @@ kind: Kustomization
 metadata:
   name: kubeflow-common
   namespace: flux-system
+  labels:
+    # Disable postBuild substitution (the cluster-apps parent injects substituteFrom into
+    # every child ks unless this label is set). The local overlay references zero ${...}
+    # vars, while the remote kubeflow/knative bases ship literal ${...} placeholders
+    # (e.g. ${REVISION_UID} in the Knative config-observability _example) that break
+    # envsubst strict mode. Same rationale/mechanism as kubeflow-apps below.
+    substitution.flux.home.arpa/disabled: "true"
 spec:
   commonMetadata:
     labels:
@@ -22,12 +29,6 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 10m
-  postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: cluster-settings
-      - kind: Secret
-        name: cluster-secrets
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/default/immich/app/server/config/immich-config.json
+++ b/kubernetes/apps/default/immich/app/server/config/immich-config.json
@@ -65,9 +65,9 @@
     "autoRegister": true,
     "buttonText": "Login with Authelia",
     "clientId": "immich",
-    "clientSecret": "${IMMICH_OAUTH_CLIENT_SECRET}",
+    "clientSecret": "",
     "defaultStorageQuota": 0,
-    "enabled": true,
+    "enabled": false,
     "issuerUrl": "https://auth.mcgrath.nz/.well-known/openid-configuration",
     "mobileOverrideEnabled": false,
     "mobileRedirectUri": "",
@@ -78,13 +78,10 @@
     "storageQuotaClaim": "immich_quota"
   },
   "passwordLogin": {
-    "enabled": false
+    "enabled": true
   },
   "reverseGeocoding": {
     "enabled": true
-  },
-  "database": {
-    "url": "postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}/${DB_DATABASE_NAME}?connection_limit=5&pool_timeout=20&connect_timeout=10"
   },
   "metadata": {
     "faces": {

--- a/kubernetes/apps/observability/grafana/app/dashboards/apps/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/apps/kustomization.yaml
@@ -16,3 +16,16 @@ generatorOptions:
     grafana_folder: Data
   labels:
     grafana_dashboard: "1"
+# These dashboards are literal ConfigMap resources, so generatorOptions.annotations
+# above never apply to them. Patch the substitute-disable annotation onto each so
+# Flux envsubst leaves Grafana template vars like ${datasource} untouched.
+patches:
+  - target:
+      kind: ConfigMap
+    patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: not-used
+        annotations:
+          kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/grafana/app/dashboards/ray/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/ray/kustomization.yaml
@@ -15,3 +15,16 @@ generatorOptions:
     grafana_folder: Ray # Put these dashboards in a 'Ray' folder in Grafana
   labels:
     grafana_dashboard: "1"
+# These dashboards are literal ConfigMap resources, so generatorOptions.annotations
+# above never apply to them. Patch the substitute-disable annotation onto each so
+# Flux envsubst leaves Grafana template vars like ${datasource} untouched.
+patches:
+  - target:
+      kind: ConfigMap
+    patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: not-used
+        annotations:
+          kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/grafana/app/dashboards/seldon/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/seldon/kustomization.yaml
@@ -11,3 +11,16 @@ generatorOptions:
     grafana_folder: Data
   labels:
     grafana_dashboard: "1"
+# These dashboards are literal ConfigMap resources, so generatorOptions.annotations
+# above never apply to them. Patch the substitute-disable annotation onto each so
+# Flux envsubst leaves Grafana template vars like ${datasource} untouched.
+patches:
+  - target:
+      kind: ConfigMap
+    patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: not-used
+        annotations:
+          kustomize.toolkit.fluxcd.io/substitute: disabled


### PR DESCRIPTION
Second batch of Flux `postBuild` envsubst (strict mode) failures, all leaving Kustomizations stuck at `Ready: False`. Follow-up to #5913.

## 1. `grafana` — `${datasource}` (112 occurrences, 12 dashboards)

The dashboard kustomizations set `kustomize.toolkit.fluxcd.io/substitute: disabled` under **`generatorOptions.annotations`** — but the dashboards are **literal ConfigMap resources**, not `configMapGenerator` output, so that annotation never lands. Flux then ran envsubst over the raw dashboard JSON and choked on the Grafana template var `${datasource}`.

Fix: add a kustomize `patches` block to each dashboard kustomization (`apps`, `ray`, `seldon`) that stamps the `substitute: disabled` annotation onto every ConfigMap (SMP, so it also creates the annotations block on the ray/seldon dashboards that lacked one). Verified all 12 ConfigMaps carry the annotation after build.

## 2. `kubeflow-common` — `${REVISION_UID}`

`config-observability` comes from the **remote** `kubeflow/manifests .../knative-serving ?ref=v1.11.0` base; `${REVISION_UID}` is a literal in Knative's `logging.revision-url-template` `_example`, not a Flux var. The local overlay references **zero** `${...}` vars.

Fix: label the ks `substitution.flux.home.arpa/disabled: "true"` so the `cluster-apps` parent stops injecting `substituteFrom` (just removing the local `postBuild` isn't enough — the parent re-injects it via a targeted patch). Same mechanism the sibling `kubeflow-apps` ks already uses.

## 3. `immich` — `${IMMICH_OAUTH_CLIENT_SECRET}` (+ latent `${DB_*}`)

OAuth was `enabled: true` pointing at a **foreign issuer** (`auth.mcgrath.nz`, "Login with Authelia") with `clientSecret: ${IMMICH_OAUTH_CLIENT_SECRET}` — a var that was never created, and there is no Authentik OIDC provider for immich. The live ConfigMap showed `clientSecret: ""` and `oauth.enabled: true` with `passwordLogin.enabled: false`.

Fix:
- Disable OAuth (`enabled: false`, blank `clientSecret`) and **enable `passwordLogin`** — both were off, which would leave no working login path.
- Remove the dead `"database"` block: not a valid immich system-config key, resolved to an empty URL (`postgresql://:@:/`) in the live ConfigMap, and immich gets its DB via `envFrom: immich-db-secret`. This also clears the latent `${DB_*}` envsubst landmines (they'd have failed next).

After the change the immich build's only remaining tokens are `${SECRET_DOMAIN}` and `${TIMEZONE}`, both provided cluster-wide.

## Notes
- No secret values touched; nothing sensitive added to the tree.
- immich behavior change: login is now local username/password instead of (broken) OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)