### PR TITLE
fix(posterizarr): work around v3.0.0 insider config-check 404 crashloop

### DIFF
--- a/kubernetes/apps/media/plex/posterizarr/app/cronjob.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/cronjob.yaml
@@ -80,5 +80,9 @@ spec:
                     -l app.kubernetes.io/name=posterizarr \
                     -o jsonpath='{.items[0].metadata.name}')"
                   echo "Triggering full Posterizarr run inside pod: $POD"
+                  # /tmp/Start.ps1 is the envsubst/CheckJson-patched copy the app
+                  # container writes at startup (see helmrelease.yaml). /app/Start.ps1
+                  # would 404 on the same config-integrity check. Revert to
+                  # /app/Start.ps1 when the upstream workaround is removed.
                   exec kubectl -n media exec "$POD" -c app -- \
-                    pwsh /app/Start.ps1 -Mode run
+                    pwsh /tmp/Start.ps1 -Mode run

--- a/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
@@ -50,6 +50,40 @@ spec:
             image:
               repository: ghcr.io/fscorrupt/posterizarr
               tag: v3.0.0@sha256:bddcf440514a2fc7552438658df6af25f7a6d90edac0c1020b34560ffbed801a
+            # Upstream workaround (remove once a fixed image is published).
+            #
+            # The v3.0.0 images report version 3.0.0, which is greater than the
+            # latest tagged release (2.2.x), so Start.ps1 flags them as an
+            # "InsiderBuild". The InsiderBuild branch of the config-integrity
+            # check fetches config.example.json from the git ref `v3.0.0`
+            # (github.com/fscorrupt/posterizarr/raw/v3.0.0/config.example.json),
+            # which does not exist upstream -> HTTP 404 -> the PowerShell
+            # process errors out and the container exits (CrashLoopBackOff).
+            # The bug is already fixed on the upstream `dev` branch (the
+            # InsiderBuild/v3.0.0 path was dropped) but no published image
+            # carries the fix yet.
+            #
+            # /app is root-owned and this container runs as uid 1000, so we
+            # can't patch /app/Start.ps1 in place. Instead we run a patched
+            # copy from /tmp that redirects the fetch to the `dev` ref (which
+            # serves the correct 3.0 example config, HTTP 200). Everything in
+            # Start.ps1 resolves via $env:APP_ROOT=/app, not the script's own
+            # location, so running the copy from /tmp is safe. The wrapper
+            # mirrors the image's /app/start.sh; port is hardcoded to 8000 to
+            # match the image default and the `http` service port (the HR sets
+            # neither APP_PORT nor DISABLE_UI), and to keep the script free of
+            # `$` so Flux envsubst leaves it untouched.
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                set -e
+                cp /app/Start.ps1 /tmp/Start.ps1
+                sed -i 's#raw/v3.0.0/config.example.json#raw/dev/config.example.json#' /tmp/Start.ps1
+                export PYTHONPATH=/app
+                echo "Starting FastAPI Web UI (API + Frontend) on port 8000..."
+                python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000 --log-level critical --no-access-log &
+                echo "Starting Posterizarr PowerShell automation..."
+                exec /usr/bin/catatonit -- pwsh -NoProfile /tmp/Start.ps1
             env:
               TZ: ${TIMEZONE}
             # NFS stale-handle watchdog: when the NAS export gets re-exported


### PR DESCRIPTION
## Problem
`posterizarr` was in `CrashLoopBackOff`. The `ghcr.io/fscorrupt/posterizarr:v3.0.0` image reports version `3.0.0` (> latest release `2.2.52`), so `Start.ps1` flags it as an **"InsiderBuild"** and its config-integrity check fetches the reference config from the git ref `v3.0.0`:

```
github.com/fscorrupt/posterizarr/raw/v3.0.0/config.example.json  → HTTP 404
```

That ref does not exist upstream (`dev` and `main` both return 200). The 404 makes the PowerShell process error out and the container exits.

- Affects **every** current `v3.0.0` digest (deployed `a9190c8` and pending `e13e1a7` both hardcode the dead URL), so a Renovate digest bump does **not** fix it.
- Already fixed on the upstream **`dev`** branch (InsiderBuild/`v3.0.0` path dropped) — but no published image carries the fix yet.

## Fix
`/app` is root-owned and the container runs as uid 1000, so `Start.ps1` can't be patched in place. Since everything in `Start.ps1` resolves via `$env:APP_ROOT=/app` (not the script's own path), we run a **patched copy from `/tmp`** that redirects the fetch to the `dev` ref (HTTP 200, correct 3.0 example config). The wrapper mirrors the image's `/app/start.sh` and is kept free of `$` so Flux envsubst leaves it untouched. The monthly CronJob runs the same `/tmp` copy.

Verified live: pod `1/1 Running`, logs show `Config check complete → Container Started → UI … online → File Watcher Started`, and the check correctly backfilled the new 3.0 config keys.

## Follow-up
Revert both files (drop the command override) once a fixed image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)