### PR TITLE
fix(flux): disable envsubst on posterizarr-configmap

### DIFF
--- a/kubernetes/apps/media/plex/posterizarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/kustomization.yaml
@@ -20,3 +20,11 @@ configMapGenerator:
       disableNameSuffixHash: true
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # config.json.template carries ${...} placeholders that are NOT Flux vars:
+    # init-config.sh fills FanartTvAPIKey/tvdbapi/tmdbtoken/PlexToken at runtime
+    # via `yq env(...)` from posterizarr-secret, and the Discord ${WebhookID}/
+    # ${WebhookToken} are inert placeholders. Flux strict-mode envsubst otherwise
+    # fails on the first unset one (FANARTTV_API_KEY), blocking the whole
+    # kustomization. Disable post-build substitution on the generated ConfigMap.
+    kustomize.toolkit.fluxcd.io/substitute: disabled


### PR DESCRIPTION
## Problem
The `posterizarr` Flux Kustomization is `READY=False`:

```
post build failed for ConfigMap/posterizarr-configmap: envsubst error:
variable not set (strict mode): "FANARTTV_API_KEY"
```

This blocks the **entire** posterizarr kustomization from applying — including the just-merged v3.0.0 crashloop workaround (#5944), which is why the fix wasn't reaching the cluster on reconcile.

## Root cause
`config/config.json.template` carries `${...}` placeholders that are **not** Flux build-time vars:
- `FanartTvAPIKey` / `tvdbapi` / `tmdbtoken` / `PlexToken` are filled at **runtime** by `init-config.sh` via `yq env(...)` from `posterizarr-secret`.
- Discord `${WebhookID}` / `${WebhookToken}` are inert placeholders.

Only `PLEX_TOKEN` exists as a global var, so Flux strict-mode envsubst fails on the first unset one (`FANARTTV_API_KEY`). Pre-existing fallout from the repo-wide strict-envsubst enablement.

## Fix
Stamp `kustomize.toolkit.fluxcd.io/substitute: disabled` onto the generated ConfigMap via `generatorOptions.annotations` — same convention as the grafana/kubeflow envsubst fixes in #5914. Verified with `kubectl kustomize`: the annotation lands on `posterizarr-configmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)