### PR TITLE
fix(posterizarr): pin to an existing image digest (bddcf44 was GC'd)

### DIFF
--- a/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
@@ -49,7 +49,14 @@ spec:
           app:
             image:
               repository: ghcr.io/fscorrupt/posterizarr
-              tag: v3.0.0@sha256:bddcf440514a2fc7552438658df6af25f7a6d90edac0c1020b34560ffbed801a
+              # Pinned to an existing digest. Upstream deleted the `v3.0.0` tag
+              # and garbage-collected the digest Renovate last pinned (bddcf44),
+              # so helm upgrades hit ImagePullBackOff -> timeout -> rollback to a
+              # crashlooping old release. e13e1a7 is the newest digest still
+              # present in ghcr and is verified healthy with the wrapper below.
+              # Renovate can't resolve the (now-missing) v3.0.0 tag, so it won't
+              # bump this until upstream restores a tag.
+              tag: v3.0.0@sha256:e13e1a782a31a6b79db55ac0e6510890270c3ad30d380b2eb5b5de510bc7ed98
             # Upstream workaround (remove once a fixed image is published).
             #
             # The v3.0.0 images report version 3.0.0, which is greater than the


### PR DESCRIPTION
## Problem
posterizarr was back in `CrashLoopBackOff` even after #5944 + #5945 merged. The Flux Kustomization is green and the in-cluster HelmRelease has the correct spec, but helm-controller is **`Stalled` (RetriesExceeded)**:

```
Helm upgrade failed: timeout waiting for: [Deployment/media/posterizarr status: 'InProgress']
Helm rollback to media/posterizarr.v285 ... failed: timeout ...
```

## Root cause
Upstream **deleted the `v3.0.0` tag** and garbage-collected the digest Renovate last pinned in #5931:

| digest | in ghcr |
|--------|---------|
| `bddcf44` (merged HR) | **404 — gone** |
| `e13e1a7` | 200 — exists |
| `a9190c8` | 200 — exists |

So helm's upgrade to `bddcf44` hit `ImagePullBackOff` → never Ready → timed out → remediation rolled back to old release `v285` (`a9190c8`), which crashloops on the same `v3.0.0` config-check 404. Hence the CrashLoopBackOff.

## Fix
Pin to `e13e1a7` — the newest digest still present in ghcr. Verified live (patched the Deployment): pod `1/1 Running`, `Config check complete → Container Started → UI online → File Watcher Started`. Renovate can't resolve the now-missing `v3.0.0` tag, so this won't churn until upstream restores a tag.

## Follow-up
When upstream publishes a fixed, tagged image, revert the command-override workaround (#5944) and repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)