### PR TITLE
fix(posterizarr): fix v3.0.0 run-path 404 that broke every run (0 libraries)

### DIFF
--- a/kubernetes/apps/media/plex/posterizarr/app/cronjob.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/cronjob.yaml
@@ -84,5 +84,11 @@ spec:
                   # container writes at startup (see helmrelease.yaml). /app/Start.ps1
                   # would 404 on the same config-integrity check. Revert to
                   # /app/Start.ps1 when the upstream workaround is removed.
+                  #
+                  # v3.0.0 renamed the run switch: Start.ps1 now takes -Run (or
+                  # --run), NOT `-Mode run`. With `-Mode run` the switch never
+                  # sets, so Start.ps1 falls through to the scheduler/watcher and
+                  # the monthly full run becomes a silent no-op (it just spawns a
+                  # duplicate watcher instead of walking every library item).
                   exec kubectl -n media exec "$POD" -c app -- \
-                    pwsh /tmp/Start.ps1 -Mode run
+                    pwsh /tmp/Start.ps1 -Run

--- a/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/posterizarr/app/helmrelease.yaml
@@ -93,6 +93,25 @@ spec:
                 exec /usr/bin/catatonit -- pwsh -NoProfile /tmp/Start.ps1
             env:
               TZ: ${TIMEZONE}
+              # v3.0.0 run-path 404 workaround (remove once a fixed image ships).
+              #
+              # The image sets APP_VERSION=3.0.0-dev. modules/core/Variables.ps1
+              # gates the config-integrity check on `APP_VERSION -match "3.0.0"`,
+              # and on match fetches config.example.json from the git ref `v3.0.0`
+              # (github.com/fscorrupt/posterizarr/raw/v3.0.0/config.example.json),
+              # which does not exist -> HTTP 404. CheckJson throws, the exception
+              # skips the Plex library fetch, and every real run (scheduler, UI
+              # "run", -Run, watcher trigger) then dies in NormalMode with
+              # "0 libraries were found". The existing /tmp/Start.ps1 sed only
+              # patches the launcher's copy, NOT the run-path module, so the
+              # container/watcher look healthy while no run ever succeeds.
+              #
+              # Overriding APP_VERSION to a string that still contains `-dev`
+              # (so Variables.ps1:L3 keeps $Branch = "dev") but NOT `3.0.0`
+              # makes L133 take the else branch and fetch from raw/dev/
+              # (HTTP 200). This fixes both the launcher and the run path, so
+              # the /tmp/Start.ps1 sed above is now redundant belt-and-suspenders.
+              APP_VERSION: "3.0.1-dev"
             # NFS stale-handle watchdog: when the NAS export gets re-exported
             # (NAS reboot, share recreation), the existing kernel mount handle
             # for /config/watcher dies with ESTALE and the watcher loop silently


### PR DESCRIPTION
## Problem

Every real Posterizarr run has been silently failing since the v3.0.0 upgrade with:

```
[ERROR] NormalMode.ps1:L.38 | 0 libraries were found. Are you on the correct Plex server?
[ERROR] System.ps1:L.36     | No libs found
```

The container, File Watcher, and Plex connectivity all look healthy (`curl $PlexUrl/library/sections?X-Plex-Token=…` returns 200 with 5 libs from inside the pod, token is valid, NFS mounts writable) — so the failure is easy to misread as a Plex/token/NFS problem. It isn't.

## Root cause

The existing `/tmp/Start.ps1` sed workaround only patched the **launcher**. The identical `raw/v3.0.0/config.example.json` 404 also lives in the **run path** at `modules/core/Variables.ps1:133`:

```powershell
if ($env:APP_VERSION -match "3.0.0") {                       # image sets APP_VERSION=3.0.0-dev -> matches
    CheckJson ... "raw/v3.0.0/config.example.json"           # 404 (ref does not exist)
} Else {
    CheckJson ... "raw/$($Branch)/config.example.json"       # raw/dev/ -> 200
}
```

`Start.ps1 -Run` / the UI "run scheduler" / watcher triggers all exec the **unpatched** `/app/Posterizarr.ps1`. Its `CheckJson` throws on the 404; the exception skips the `CheckPlexAccess` fetch, leaving `$Libs` empty, and `NormalMode` then reports "0 libraries." Confirmed by tracing the live pod: with `APP_VERSION` overridden, the same run found 4 libs / 1871 items.

## Fix

- **helmrelease.yaml**: add env `APP_VERSION: "3.0.1-dev"`. Keeps `-dev` (so `Variables.ps1:L3` sets `$Branch=dev`) but drops the `3.0.0` substring, so L133 fetches `raw/dev/` (200). Fixes launcher **and** run path in one line; the `/tmp/Start.ps1` sed is now redundant belt-and-suspenders.
- **cronjob.yaml**: `-Mode run` → `-Run`. v3.0.0 renamed the switch (`param([switch]$Run)`); `-Mode run` never set it, so the monthly full run was a silent no-op that just spawned a duplicate watcher.

## Verification

- Traced end-to-end in the running pod (`media/posterizarr`): 404 at `Variables.ps1:133`, empty `$Libs`, `NormalMode:L.38` exit.
- Proof run with `APP_VERSION=3.0.1-dev`: passed config check, `Found '4' libs`, `Query all items… Found '1871' Items`.
- Both files pass `yaml.safe_load_all`.

Revert once an upstream image ships the fix (the InsiderBuild/v3.0.0 path is already dropped on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)